### PR TITLE
refactor: remove all typedefs for structures and enumerations

### DIFF
--- a/include/arch/register.h
+++ b/include/arch/register.h
@@ -2,10 +2,10 @@
 
 #include <types.h>
 
-typedef struct {
+struct registers {
 	uint32_t gs, fs, es, ds;
 	uint32_t edi, esi, ebp, esp, ebx, edx, ecx, eax;
-} __attribute__((packed)) REGISTERS;
+} __attribute__((packed));
 
 static inline void clean_registers(void)
 {

--- a/include/arch/trap_frame.h
+++ b/include/arch/trap_frame.h
@@ -3,8 +3,8 @@
 #include <arch/register.h>
 #include <types.h>
 
-typedef struct {
-	REGISTERS regs;
+struct trap_frame {
+	struct registers regs;
 
 	uint32_t int_no;
 	uint32_t err_code;
@@ -15,4 +15,4 @@ typedef struct {
 
 	uint32_t user_esp;
 	uint32_t user_ss;
-} __attribute__((packed)) trap_frame_t;
+} __attribute__((packed));

--- a/include/arch/x86.h
+++ b/include/arch/x86.h
@@ -3,15 +3,15 @@
 #include <arch/trap_frame.h>
 #include <types.h>
 
-typedef struct {
+struct gdtr {
 	uint16_t  limit;
 	uintptr_t base;
-} __attribute__((packed)) gdtr_t;
+} __attribute__((packed));
 
-typedef struct {
+struct idtr {
 	uint16_t  limit;
 	uintptr_t base;
-} __attribute__((packed)) idtr_t;
+} __attribute__((packed));
 
 ///////////////////////////////////////////////////
 // Gdt flags
@@ -80,12 +80,12 @@ enum Gdt_Access_Byte {
 ///////////////////////////////////////////////////
 // Others
 
-typedef void (*irqHandler)(trap_frame_t *frame);
+typedef void (*irqHandler)(struct trap_frame *frame);
 
-void          init(void);
-const gdtr_t *get_gdtr(void);
-const idtr_t *get_idtr(void);
-void          gdt_init(void);
-void          idt_init(void);
-void          set_tss_to_kstack_top(uintptr_t stack_top);
-void          idt_register_interrupt_handlers(uint8_t num, irqHandler handler);
+void               init(void);
+const struct gdtr *get_gdtr(void);
+const struct idtr *get_idtr(void);
+void               gdt_init(void);
+void               idt_init(void);
+void               set_tss_to_kstack_top(uintptr_t stack_top);
+void               idt_register_interrupt_handlers(uint8_t num, irqHandler handler);

--- a/include/drivers/keyboard.h
+++ b/include/drivers/keyboard.h
@@ -21,21 +21,15 @@
 
 // Enums
 
-typedef enum { QWERTY = 0, AZERTY } Layout;
+enum layout { QWERTY = 0, AZERTY };
 
 // Structures
 
 // Typedefs
 
-typedef enum {
-	KEY_ALPHANUMERIC = 0,
-	KEY_CONTROL,
-	KEY_NAVIGATION,
-	KEY_FUNCTION,
-	KEY_SPECIAL
-} KeyCategory;
+enum key_category { KEY_ALPHANUMERIC = 0, KEY_CONTROL, KEY_NAVIGATION, KEY_FUNCTION, KEY_SPECIAL };
 
-typedef enum {
+enum key_undergroup {
 	NONE = 0,
 	LETTER,
 	TOP_KEY,
@@ -48,18 +42,18 @@ typedef enum {
 	BACKSPACE,
 	ENTER,
 	ESCAPE
-} KeyUndergroup;
+};
 
-typedef struct keyboard_key {
-	uint16_t      value;
-	uint16_t      alt_value;
-	uint16_t      keycode;
-	KeyCategory   category;
-	KeyUndergroup undergroup;
-	bool         *state_ptr;
-} keyboard_key_t;
+struct keyboard_key {
+	uint16_t            value;
+	uint16_t            alt_value;
+	uint16_t            keycode;
+	enum key_category   category;
+	enum key_undergroup undergroup;
+	bool               *state_ptr;
+};
 
-typedef void (*key_handler_t)(keyboard_key_t);
+typedef void (*key_handler_t)(struct keyboard_key);
 
 // ============================================================================
 // VARIABLES GLOBALES
@@ -69,9 +63,9 @@ typedef void (*key_handler_t)(keyboard_key_t);
 // EXTERNAL APIs
 // ============================================================================
 
-void keyboard_bind_key(key_handler_t handler, keyboard_key_t key);
+void keyboard_bind_key(key_handler_t handler, struct keyboard_key key);
 void keyboard_unbind_key(uint8_t keycode);
-void keyboard_handle(trap_frame_t *frame);
+void keyboard_handle(struct trap_frame *frame);
 void keyboard_init(void);
-void keyboard_remap_layout(keyboard_key_t *table, uint32_t size);
-void keyboard_switch_layout(Layout new_layout);
+void keyboard_remap_layout(struct keyboard_key *table, uint32_t size);
+void keyboard_switch_layout(enum layout new_layout);

--- a/include/drivers/tty.h
+++ b/include/drivers/tty.h
@@ -7,27 +7,26 @@
 #define MAX_CMD_LEN   256
 #define TTY_PROMPT    "$> "
 
-typedef struct tty_history {
+struct tty_history {
 	bool   status;
 	bool   stop_scroll;
 	size_t top_line_save;
-} tty_history;
+};
 
-typedef struct TTY {
-	vga_entry      *framebuffer;
-	size_t          framebuffer_size;
-	uint8_t         top_line_index;
-	tty_history     history;
-	struct s_cursor cursor;
-	uint8_t         mode;
-	char            cli[256];
-
-} TTY;
+struct tty {
+	struct vga_entry  *framebuffer;
+	size_t             framebuffer_size;
+	uint8_t            top_line_index;
+	struct tty_history history;
+	struct s_cursor    cursor;
+	uint8_t            mode;
+	char               cli[256];
+};
 
 void ttys_init(void);
-void tty_init(TTY *tty);
-void tty_load(TTY *tty);
-void tty_switch(TTY *tty);
+void tty_init(struct tty *tty);
+void tty_load(struct tty *tty);
+void tty_switch(struct tty *tty);
 void tty_framebuffer_switch_color(uint8_t mode);
 void tty_cli_handle_nl(void);
 void tty_framebuffer_set_screen_mode(enum vga_color mode);
@@ -40,5 +39,5 @@ void tty_history_disable(void);
 void tty_history_scroll_up(void);
 void tty_history_scroll_down(void);
 
-extern TTY *current_tty;
-extern TTY  ttys[MAX_TTY];
+extern struct tty *current_tty;
+extern struct tty  ttys[MAX_TTY];

--- a/include/drivers/vga.h
+++ b/include/drivers/vga.h
@@ -16,7 +16,7 @@
 #define VGA_HEIGHT        25
 #define VGA_COLOR(bg, fg) ((bg) << 4 | (fg))
 #define VGA_DEFAULT_MODE  VGA_COLOR(VGA_COLOR_BLUE, VGA_COLOR_WHITE)
-#define VGA_BUFFER        ((vga_entry *)((uintptr_t)0xB8000 + KERNEL_VADDR_BASE))
+#define VGA_BUFFER        ((struct vga_entry *)((uintptr_t)0xB8000 + KERNEL_VADDR_BASE))
 #define VGA_ENTRY(x, y)   (VGA_BUFFER + ((y) * VGA_WIDTH + (x)))
 
 // Macros
@@ -46,10 +46,10 @@ enum vga_color {
 };
 
 // Structures
-typedef struct __attribute__((packed)) {
+struct vga_entry {
 	uint8_t character;
 	uint8_t mode;
-} vga_entry;
+} __attribute__((packed));
 
 struct s_cursor {
 	uint8_t x;

--- a/include/kernel/io_stream.h
+++ b/include/kernel/io_stream.h
@@ -4,37 +4,38 @@
 
 struct io_stream;
 
-typedef struct io_ops {
+struct io_ops {
 	bool (*open)(struct io_stream *stream);
 	ssize_t (*read)(struct io_stream *stream, void *dest, size_t size);
 	ssize_t (*write)(struct io_stream *stream, const void *src, size_t size);
 	ssize_t (*seek)(struct io_stream *stream, ssize_t offset, int origin);
 	void (*close)(struct io_stream *stream);
-} io_ops_t;
-
-typedef struct io_stream {
-	io_ops_t *ops;
-	void     *ctx;
-	size_t    size;
-	size_t    pos;
-} io_stream_t;
+};
 
 #define SEEK_SET 0
 #define SEEK_CUR 1
 #define SEEK_END 2
 
-typedef struct {
+struct mem_stream_ctx {
 	const void *buffer;
 	size_t      size;
-} mem_stream_ctx_t;
+};
 
-static inline io_stream_t *io_stream_get_new(void *ctx, size_t size, size_t pos)
+struct io_stream {
+	struct io_ops *ops;
+	void          *ctx;
+	size_t         size;
+	size_t         pos;
+};
+
+static inline struct io_stream *io_stream_get_new(void *ctx, size_t size, size_t pos)
 {
-	io_stream_t *ret = kmalloc(sizeof(io_stream_t) + sizeof(io_ops_t), GFP_KERNEL | __GFP_ZERO);
+	struct io_stream *ret =
+	    kmalloc(sizeof(struct io_stream) + sizeof(struct io_ops), GFP_KERNEL | __GFP_ZERO);
 	if (!ret)
 		return NULL;
 
-	ret->ops = (io_ops_t *)(ret + 1);
+	ret->ops = (struct io_ops *)(ret + 1);
 
 	ret->ctx  = ctx;
 	ret->size = size;
@@ -42,27 +43,27 @@ static inline io_stream_t *io_stream_get_new(void *ctx, size_t size, size_t pos)
 	return ret;
 }
 
-static inline bool io_open(io_stream_t *s)
+static inline bool io_open(struct io_stream *s)
 {
 	return s && s->ops && s->ops->open ? s->ops->open(s) : true;
 }
 
-static inline ssize_t io_read(io_stream_t *s, void *d, size_t n)
+static inline ssize_t io_read(struct io_stream *s, void *d, size_t n)
 {
 	return s && s->ops && s->ops->read ? s->ops->read(s, d, n) : -1;
 }
 
-static inline ssize_t io_write(io_stream_t *s, const void *d, size_t n)
+static inline ssize_t io_write(struct io_stream *s, const void *d, size_t n)
 {
 	return s && s->ops && s->ops->write ? s->ops->write(s, d, n) : -1;
 }
 
-static inline ssize_t io_seek(io_stream_t *s, ssize_t off, int w)
+static inline ssize_t io_seek(struct io_stream *s, ssize_t off, int w)
 {
 	return s && s->ops && s->ops->seek ? s->ops->seek(s, off, w) : -1;
 }
 
-static inline void io_close(io_stream_t *s)
+static inline void io_close(struct io_stream *s)
 {
 	if (!s)
 		return;

--- a/include/kernel/mb2_info.h
+++ b/include/kernel/mb2_info.h
@@ -5,14 +5,13 @@
 
 #define TAGS_NEEDED 1
 
-typedef struct multiboot_tag_mmap multiboot_tag_mmap_t;
 typedef void (*entry_handler_t)(uintptr_t start, uintptr_t end);
 
-typedef struct multiboot_info {
+struct multiboot_info {
 	uint32_t             total_size;
 	uint32_t             reserved;
 	struct multiboot_tag tags[0];
-} multiboot_info_t;
+};
 
 struct multiboot2_header_tag_end {
 	uint16_t type;
@@ -30,14 +29,14 @@ struct multiboot2_header_tag_information_request {
 extern const struct multiboot_header                          mb2_header;
 extern const struct multiboot2_header_tag_information_request mb2_tag_info_req;
 extern const struct multiboot2_header_tag_end                 mb2_tag_end;
-extern multiboot_info_t                                      *mb2info;
+extern struct multiboot_info                                 *mb2info;
 
-static inline multiboot_memory_map_t *next_entry(multiboot_memory_map_t *mmap_entry,
-                                                 multiboot_tag_mmap_t   *mmap)
+static inline struct multiboot_mmap_entry *next_entry(struct multiboot_mmap_entry *mmap_entry,
+                                                      struct multiboot_tag_mmap   *mmap)
 {
-	return (multiboot_memory_map_t *)((uint8_t *)mmap_entry + mmap->entry_size);
+	return (struct multiboot_mmap_entry *)((uint8_t *)mmap_entry + mmap->entry_size);
 }
 
-void mb2_mmap_iter(multiboot_tag_mmap_t *mmap, uint8_t *mmap_end, entry_handler_t handler,
+void mb2_mmap_iter(struct multiboot_tag_mmap *mmap, uint8_t *mmap_end, entry_handler_t handler,
                    bool free);
 void mb2_init(void);

--- a/include/memory/boot_allocator.h
+++ b/include/memory/boot_allocator.h
@@ -26,15 +26,10 @@ enum mem_type { FREE_MEMORY = 0, RESERVED_MEMORY, HOLES_MEMORY };
 
 // Structures
 
-struct region_s {
+struct region {
 	uintptr_t start;
 	uintptr_t end;
 };
-
-// Typedefs
-
-typedef struct region_s       region_t;
-typedef struct boot_allocator boot_allocator_t;
 
 // ============================================================================
 // VARIABLES GLOBALES
@@ -44,20 +39,20 @@ typedef struct boot_allocator boot_allocator_t;
 // EXTERNAL APIs
 // ============================================================================
 
-uint32_t  boot_allocator_get_res_zones_count(int type);
-uint32_t  boot_allocator_get_free_zones_count(int type);
-uint32_t  boot_allocator_get_region_count(enum mem_type type);
-region_t *boot_allocator_get_res_zone(int type);
-region_t *boot_allocator_get_free_zone(int type);
-region_t *boot_allocator_get_region(enum mem_type type);
-void     *boot_alloc(uint32_t size, zone_type zone, bool freeable);
-void *boot_alloc_at(uint32_t size, zone_type zone, bool freeable, uintptr_t start, uintptr_t end,
-                    int align);
-bool  boot_allocator_range_overlaps(uintptr_t start, uintptr_t end, enum mem_type type);
-void  boot_allocator_freeze(void);
-void  boot_allocator_print_inital_layout(void);
-void  boot_allocator_res_zones_printer(void);
-void  boot_allocator_free_zones_printer(void);
-void  boot_allocator_init(multiboot_tag_mmap_t *mmap, uint8_t *mmap_end);
-void  boot_alloc_clean_up(void);
-void  boot_allocator_print_allocations(void);
+uint32_t       boot_allocator_get_res_zones_count(int type);
+uint32_t       boot_allocator_get_free_zones_count(int type);
+uint32_t       boot_allocator_get_region_count(enum mem_type type);
+struct region *boot_allocator_get_res_zone(int type);
+struct region *boot_allocator_get_free_zone(int type);
+struct region *boot_allocator_get_region(enum mem_type type);
+void          *boot_alloc(uint32_t size, enum zone_type zone, bool freeable);
+void          *boot_alloc_at(uint32_t size, enum zone_type zone, bool freeable, uintptr_t start,
+                             uintptr_t end, int align);
+bool           boot_allocator_range_overlaps(uintptr_t start, uintptr_t end, enum mem_type type);
+void           boot_allocator_freeze(void);
+void           boot_allocator_print_inital_layout(void);
+void           boot_allocator_res_zones_printer(void);
+void           boot_allocator_free_zones_printer(void);
+void           boot_allocator_init(struct multiboot_tag_mmap *mmap, uint8_t *mmap_end);
+void           boot_alloc_clean_up(void);
+void           boot_allocator_print_allocations(void);

--- a/include/memory/buddy.h
+++ b/include/memory/buddy.h
@@ -27,7 +27,7 @@
 
 // Enums
 
-typedef enum {
+enum order_size {
 	ORDER_4KIB = 0,
 	ORDER_8KIB,
 	ORDER_16KIB,
@@ -40,7 +40,7 @@ typedef enum {
 	ORDER_2MIB,
 	ORDER_4MIB,
 	BAD_ORDER,
-} order_size;
+};
 
 // Structures
 
@@ -54,8 +54,6 @@ struct buddy_allocator {
 };
 
 // Typedefs
-
-typedef struct buddy_allocator buddy_allocator_t;
 
 // Structures
 
@@ -71,4 +69,4 @@ typedef struct buddy_allocator buddy_allocator_t;
 
 void   debug_buddy(void);
 void   buddy_print_summary(void);
-size_t buddy_print(zone_type zone);
+size_t buddy_print(enum zone_type zone);

--- a/include/memory/memory.h
+++ b/include/memory/memory.h
@@ -70,14 +70,14 @@
 
 enum allocator_state { ACTIVE = 0, FROZEN };
 
-typedef enum { LOWMEM_ZONE = 0, DMA_ZONE, HIGHMEM_ZONE, INVALID_ZONE } zone_type;
+enum zone_type { LOWMEM_ZONE = 0, DMA_ZONE, HIGHMEM_ZONE, INVALID_ZONE };
 
-typedef enum {
+enum migration_type {
 	MIGRATE_MOVABLE = 0,
 	// Not Implemented
 	MIGRATE_UNMOVABLE,
 	MIGRATE_RECLAIMABLE,
-} migration_type;
+};
 
 // Structures
 
@@ -93,7 +93,7 @@ typedef unsigned int gfp_t;
 // EXTERNAL APIs
 // ============================================================================
 
-uintptr_t *buddy_alloc_pages(size_t size, zone_type zone);
+uintptr_t *buddy_alloc_pages(size_t size, enum zone_type zone);
 void       buddy_free_block(void *ptr);
 void       buddy_init(void);
 void       vmm_finalize(void);

--- a/include/memory/page.h
+++ b/include/memory/page.h
@@ -51,7 +51,7 @@
 
 // Enums
 
-typedef enum { NEXT = 0, PREV } direction;
+enum direction { NEXT = 0, PREV };
 
 // Structures
 
@@ -61,31 +61,27 @@ struct page {
 	uintptr_t        private_data;
 };
 
-// Typedefs
-
-typedef struct page page_t;
-
 // ============================================================================
 // VARIABLES GLOBALES
 // ============================================================================
 
-extern uint32_t total_pages;
-extern uint32_t total_RAM;
-extern page_t  *page_descriptors;
+extern uint32_t     total_pages;
+extern uint32_t     total_RAM;
+extern struct page *page_descriptors;
 
 // ============================================================================
 // EXTERNAL APIs
 // ============================================================================
 
-void      page_print_info(page_t *page);
-void      page_descriptor_init(void);
-uint32_t  page_to_index(page_t *page);
-uintptr_t page_to_phys(page_t *page);
-page_t   *page_index_to_page(uint32_t idx);
-page_t   *page_addr_to_page(uintptr_t addr);
-page_t   *page_addr_to_usable(uintptr_t addr, bool direction);
-uint32_t  page_get_updated_reserved_count(void);
-uint32_t  page_get_updated_free_count(void);
-uint32_t  page_get_free_count(void);
-uint32_t  page_get_reserved_count(void);
-bool      page_addr_is_same_page(uintptr_t addr1, uintptr_t addr2);
+void         page_print_info(struct page *page);
+void         page_descriptor_init(void);
+uint32_t     page_to_index(struct page *page);
+uintptr_t    page_to_phys(struct page *page);
+struct page *page_index_to_page(uint32_t idx);
+struct page *page_addr_to_page(uintptr_t addr);
+struct page *page_addr_to_usable(uintptr_t addr, enum direction direction);
+uint32_t     page_get_updated_reserved_count(void);
+uint32_t     page_get_updated_free_count(void);
+uint32_t     page_get_free_count(void);
+uint32_t     page_get_reserved_count(void);
+bool         page_addr_is_same_page(uintptr_t addr1, uintptr_t addr2);

--- a/include/memory/slab.h
+++ b/include/memory/slab.h
@@ -22,22 +22,21 @@
 
 // Structures
 
-typedef struct slab_cache {
+struct slab_cache {
 	struct list_head slabs_full;
 	struct list_head slabs_partial;
 	struct list_head slabs_empty;
 	size_t           object_size;
 	uint32_t         objects_per_slab;
+};
 
-} slab_cache_t;
-
-typedef struct slab {
-	struct list_head list;
-	void            *freelist;
-	uint32_t         inuse;
-	slab_cache_t    *parent_cache;
-	char             _padding[12];
-} slab_t;
+struct slab {
+	struct list_head   list;
+	void              *freelist;
+	uint32_t           inuse;
+	struct slab_cache *parent_cache;
+	char               _padding[12];
+};
 
 // Typedefs
 
@@ -51,6 +50,6 @@ typedef struct slab {
 
 void  slab_init(void);
 void  slab_free(void *ptr);
-void *slab_alloc(size_t size, zone_type zone);
+void *slab_alloc(size_t size, enum zone_type zone);
 void  slab_print_summary(void);
-void  slab_shrink_caches(zone_type zone);
+void  slab_shrink_caches(enum zone_type zone);

--- a/include/memory/vmm.h
+++ b/include/memory/vmm.h
@@ -112,7 +112,7 @@ enum Page_Directory_Entry {
 
 // EXTERNAL APIs
 
-void      page_fault_handler(trap_frame_t *frame);
+void      page_fault_handler(struct trap_frame *frame);
 uintptr_t vmm_get_mapping(uintptr_t page_dir_phys, uintptr_t v_addr);
 bool      vmm_map_page(uintptr_t page_dir_phys, uintptr_t v_addr, uintptr_t p_addr, uint32_t flags);
 bool      vmm_unmap_page(uintptr_t page_dir_phys, uintptr_t v_addr);

--- a/include/proc/section.h
+++ b/include/proc/section.h
@@ -32,14 +32,14 @@
 // STRUCTS & MACROS
 // ============================================================================
 
-typedef struct section {
+struct section {
 	uintptr_t v_addr;
 	uintptr_t p_addr;
 	uintptr_t data_start;
 	uint32_t  data_size;
 	uint32_t  mapping_size;
 	uint32_t  flags;
-} section_t;
+};
 
 // ============================================================================
 // EXTERNAL APIs
@@ -47,7 +47,7 @@ typedef struct section {
 
 struct io_stream;
 
-bool section_init_from_buffer(section_t *sec, uintptr_t v_addr, const void *buffer, uint32_t size,
-                              uint32_t flags);
+bool section_init_from_buffer(struct section *sec, uintptr_t v_addr, const void *buffer,
+                              uint32_t size, uint32_t flags);
 
-struct io_stream *section_create_reader(section_t *sec);
+struct io_stream *section_create_reader(struct section *sec);

--- a/include/proc/task.h
+++ b/include/proc/task.h
@@ -30,10 +30,10 @@ struct task {
 	uintptr_t kernel_stack_pointer;
 	uintptr_t kernel_stack_base;
 
-	section_t *text_sec;
-	section_t *data_sec;
-	section_t *stack_sec;
-	section_t *heap_sec;
+	struct section *text_sec;
+	struct section *data_sec;
+	struct section *stack_sec;
+	struct section *heap_sec;
 
 	/* Scheduling */
 	struct task        *next; // Used for "Round Robin"
@@ -50,12 +50,12 @@ struct task {
 extern void task_launcher(struct task *next);
 extern void task_user_launcher(struct task *next);
 
-static inline section_t *task_text(struct task *new_task) { return new_task->text_sec; }
-static inline section_t *task_data(struct task *new_task) { return new_task->data_sec; }
-static inline section_t *task_heap(struct task *new_task) { return new_task->heap_sec; }
-static inline section_t *task_stack(struct task *new_task) { return new_task->stack_sec; }
+static inline struct section *task_text(struct task *new_task) { return new_task->text_sec; }
+static inline struct section *task_data(struct task *new_task) { return new_task->data_sec; }
+static inline struct section *task_heap(struct task *new_task) { return new_task->heap_sec; }
+static inline struct section *task_stack(struct task *new_task) { return new_task->stack_sec; }
 
 void         task_print_info(const struct task *task);
 void         task_print_stack(const struct task *task);
-struct task *task_get_new(char *name, bool userspace, section_t *text, section_t *data);
+struct task *task_get_new(char *name, bool userspace, struct section *text, struct section *data);
 void         task_init_idle(void);

--- a/src/arch/x86/gdt.c
+++ b/src/arch/x86/gdt.c
@@ -30,7 +30,7 @@ struct segment_descriptor {
 
 // Code
 
-gdtr_t                    gdtr;
+struct gdtr               gdtr;
 struct segment_descriptor gdt_entries[GDT_MAX_ENTRIES];
 
 static inline void gdt_set_entry(struct segment_descriptor *gdt_entry, uint32_t base,
@@ -45,7 +45,7 @@ static inline void gdt_set_entry(struct segment_descriptor *gdt_entry, uint32_t 
 	gdt_entry->base_high   = (base >> 24) & 0xFF;
 }
 
-const gdtr_t *get_gdtr(void) { return &gdtr; }
+const struct gdtr *get_gdtr(void) { return &gdtr; }
 
 void set_tss_to_kstack_top(uintptr_t stack_top) { g_tss.esp0 = stack_top; }
 

--- a/src/arch/x86/idt.c
+++ b/src/arch/x86/idt.c
@@ -9,13 +9,13 @@
 #include <memory/memory.h>
 #include <types.h>
 
-typedef struct __attribute__((packed)) {
+struct idt_entry {
 	uint16_t offset_1;
 	uint16_t selector;
 	uint8_t  zero;
 	uint8_t  type_attributes;
 	uint16_t offset_2;
-} idt_entry;
+} __attribute__((packed));
 
 enum IDTTypeAttributes {
 	TaskGate    = 0x05,
@@ -32,7 +32,7 @@ enum IDTTypeAttributes {
 	PresentBit = 0x01 << 7
 };
 
-typedef void (*syscallHandler)(trap_frame_t *frame);
+typedef void (*syscallHandler)(struct trap_frame *frame);
 
 #define IDT_SIZE        256
 #define IDT_ENTRY(indx) (idt_entries + (indx))
@@ -110,10 +110,11 @@ extern void irq_47(void);
 // [...]
 extern void irq_128(void);
 
-extern void syscall_dispatcher(trap_frame_t *frame);
+extern void syscall_dispatcher(struct trap_frame *frame);
 
-idt_entry idt_entries[IDT_SIZE];
-idtr_t    idtr = {.limit = sizeof(idt_entry) * IDT_SIZE - 1, .base = (uintptr_t)&idt_entries};
+struct idt_entry idt_entries[IDT_SIZE];
+struct idtr      idtr = {.limit = sizeof(struct idt_entry) * IDT_SIZE - 1,
+                         .base  = (uintptr_t)&idt_entries};
 
 irqHandler interrupt_handlers[256] = {
     [0x80] = syscall_dispatcher,
@@ -154,7 +155,7 @@ const char *interrupt_names[] = {"Divide Error",
                                  "Security Exception",
                                  "Reserved"};
 
-void exception_handler(trap_frame_t *frame)
+void exception_handler(struct trap_frame *frame)
 {
 	if (interrupt_handlers[frame->int_no] != NULL)
 		interrupt_handlers[frame->int_no](frame);
@@ -192,7 +193,8 @@ static void init_pic(void)
 	outb(PIC2_DATA, 0x00);
 }
 
-static inline void idt_set_entry(idt_entry *ptr, uint16_t selector, uint8_t type, uint32_t offset)
+static inline void idt_set_entry(struct idt_entry *ptr, uint16_t selector, uint8_t type,
+                                 uint32_t offset)
 {
 	ptr->offset_1        = offset & 0xffff;
 	ptr->offset_2        = (offset & 0xffff0000) >> 16;
@@ -200,12 +202,12 @@ static inline void idt_set_entry(idt_entry *ptr, uint16_t selector, uint8_t type
 	ptr->type_attributes = type;
 }
 
-const idtr_t *get_idtr(void) { return &idtr; }
+const struct idtr *get_idtr(void) { return &idtr; }
 
 void idt_init(void)
 {
 	init_pic();
-	ft_bzero((void *)&idt_entries, sizeof(idt_entry) * IDT_SIZE);
+	ft_bzero((void *)&idt_entries, sizeof(struct idt_entry) * IDT_SIZE);
 
 	idt_set_entry(IDT_ENTRY(0x00), 0x08, PresentBit | IntGate_32 | CPU_Ring0, (uint32_t)isr_0);
 	idt_set_entry(IDT_ENTRY(0x01), 0x08, PresentBit | IntGate_32 | CPU_Ring0, (uint32_t)isr_1);

--- a/src/drivers/keyboard/keyboard.c
+++ b/src/drivers/keyboard/keyboard.c
@@ -2,12 +2,12 @@
 #include "layout.h"
 #include <arch/trap_frame.h>
 
-Layout             current_layout_type = QWERTY;
-scancode_routine_t current_layout[256] = {0};
+enum layout             current_layout_type = QWERTY;
+struct scancode_routine current_layout[256] = {0};
 
 // Printable Group
 
-static char keyboard_get_shifted_value(keyboard_key_t key)
+static char keyboard_get_shifted_value(struct keyboard_key key)
 {
 	bool shift = left_shift || right_shift;
 
@@ -19,7 +19,7 @@ static char keyboard_get_shifted_value(keyboard_key_t key)
 	return key.value;
 }
 
-static void keyboard_printable_handler(keyboard_key_t key)
+static void keyboard_printable_handler(struct keyboard_key key)
 {
 	char   ascii   = keyboard_get_shifted_value(key);
 	size_t cmd_len = ft_strlen(current_tty->cli);
@@ -36,19 +36,19 @@ static void keyboard_printable_handler(keyboard_key_t key)
 
 // Control Group
 
-static void keyboard_toggle_handler(keyboard_key_t key)
+static void keyboard_toggle_handler(struct keyboard_key key)
 {
 	if (key.state_ptr)
 		*(key.state_ptr) = !*(key.state_ptr);
 }
 
-static void keyboard_press_handler(keyboard_key_t key)
+static void keyboard_press_handler(struct keyboard_key key)
 {
 	if (key.state_ptr && *(key.state_ptr) == false)
 		*(key.state_ptr) = true;
 }
 
-static void keyboard_release_handler(keyboard_key_t key)
+static void keyboard_release_handler(struct keyboard_key key)
 {
 	if (key.state_ptr && *(key.state_ptr) == true)
 		*(key.state_ptr) = false;
@@ -72,7 +72,7 @@ static key_handler_t keyboard_get_control_handler(uint8_t state)
 
 // Navigation Group
 
-static void keyboard_navigation_handler(keyboard_key_t key)
+static void keyboard_navigation_handler(struct keyboard_key key)
 {
 	if (key.value == COLOR_PGUP || (key.value == COLOR_UP && left_ctrl))
 		tty_history_enable();
@@ -91,25 +91,25 @@ static void keyboard_navigation_handler(keyboard_key_t key)
 
 // Function Group
 
-static void keyboard_function_handler(keyboard_key_t key) { tty_switch(ttys + key.value); }
+static void keyboard_function_handler(struct keyboard_key key) { tty_switch(ttys + key.value); }
 
 // Function Group
 
 // Special Group
 
-static void keyboard_enter_handler(keyboard_key_t key)
+static void keyboard_enter_handler(struct keyboard_key key)
 {
 	(void)key;
 	tty_cli_handle_nl();
 }
 
-static void keyboard_escape_handler(keyboard_key_t key)
+static void keyboard_escape_handler(struct keyboard_key key)
 {
 	(void)key;
 	shutdown();
 }
 
-static void keyboard_backspace_handler(keyboard_key_t key)
+static void keyboard_backspace_handler(struct keyboard_key key)
 {
 	int len = ft_strlen(current_tty->cli);
 
@@ -154,7 +154,7 @@ static key_handler_t keyboard_get_special_handler(uint8_t undergroup)
 
 // Internal API
 
-static key_handler_t keyboard_get_default_key_handler(keyboard_key_t key)
+static key_handler_t keyboard_get_default_key_handler(struct keyboard_key key)
 {
 	switch (key.category) {
 	case KEY_ALPHANUMERIC:
@@ -175,8 +175,8 @@ static key_handler_t keyboard_get_default_key_handler(keyboard_key_t key)
 
 static void keyboard_init_default_table(void)
 {
-	keyboard_key_t *groups[] = {printable_keys, control_keys, navigation_keys,
-	                            function_keys,  special_keys, NULL};
+	struct keyboard_key *groups[] = {printable_keys, control_keys, navigation_keys,
+	                                 function_keys,  special_keys, NULL};
 
 	for (uint32_t g = 0; groups[g] != NULL; g++) {
 		for (uint32_t i = 0; groups[g][i].keycode != UNDEFINED; i++) {
@@ -188,7 +188,7 @@ static void keyboard_init_default_table(void)
 
 // External API
 
-void keyboard_switch_layout(Layout new_layout)
+void keyboard_switch_layout(enum layout new_layout)
 {
 	if (current_layout_type == new_layout) {
 		vga_printf("\nkeyboard: Layout already set");
@@ -203,7 +203,7 @@ void keyboard_switch_layout(Layout new_layout)
 	current_layout_type = new_layout;
 }
 
-void keyboard_remap_layout(keyboard_key_t *table, uint32_t size)
+void keyboard_remap_layout(struct keyboard_key *table, uint32_t size)
 {
 	if (size == STOP_WHEN_UNDEFINED) {
 		uint32_t i = 0;
@@ -223,22 +223,22 @@ void keyboard_remap_layout(keyboard_key_t *table, uint32_t size)
 }
 
 // TODO : register dimamically when memory is implemented
-void keyboard_bind_key(key_handler_t handler, keyboard_key_t key)
+void keyboard_bind_key(key_handler_t handler, struct keyboard_key key)
 {
-	current_layout[key.keycode] = (scancode_routine_t){.handler = handler, .key = key};
+	current_layout[key.keycode] = (struct scancode_routine){.handler = handler, .key = key};
 }
 
 // TODO : use free when memory
 void keyboard_unbind_key(uint8_t keycode) { current_layout[keycode] = UNDEFINED_ROUTINE; }
 
 // TODO : improve to add statement handling + init dynamically when memory is implemented
-void keyboard_handle(trap_frame_t *frame)
+void keyboard_handle(struct trap_frame *frame)
 {
 	(void)frame;
 	if (inb(0x64) & 0x01) {          // read status
 		uint8_t keycode = inb(0x60); // read data
 		if (current_layout[keycode].handler) {
-			keyboard_key_t key = current_layout[keycode].key;
+			struct keyboard_key key = current_layout[keycode].key;
 			current_layout[keycode].handler(key);
 		}
 	}

--- a/src/drivers/keyboard/keyboard.h
+++ b/src/drivers/keyboard/keyboard.h
@@ -24,14 +24,14 @@
 
 // Macros
 #define UNDEFINED_KEY                                                                              \
-	((keyboard_key_t){.value      = UNDEFINED,                                                     \
-	                  .alt_value  = UNDEFINED,                                                     \
-	                  .keycode    = UNDEFINED,                                                     \
-	                  .category   = UNDEFINED,                                                     \
-	                  .undergroup = UNDEFINED,                                                     \
-	                  .state_ptr  = NULL})
+	((struct keyboard_key){.value      = UNDEFINED,                                                \
+	                       .alt_value  = UNDEFINED,                                                \
+	                       .keycode    = UNDEFINED,                                                \
+	                       .category   = UNDEFINED,                                                \
+	                       .undergroup = UNDEFINED,                                                \
+	                       .state_ptr  = NULL})
 
-#define UNDEFINED_ROUTINE ((scancode_routine_t){.key = UNDEFINED_KEY, .handler = NULL})
+#define UNDEFINED_ROUTINE ((struct scancode_routine){.key = UNDEFINED_KEY, .handler = NULL})
 
 // ============================================================================
 // STRUCT
@@ -41,12 +41,12 @@
 
 // Structures
 typedef void (*group_init_funs_t)(void);
-typedef void (*key_handler_t)(keyboard_key_t);
+typedef void (*key_handler_t)(struct keyboard_key);
 
-typedef struct scancode_routine {
-	keyboard_key_t key;
-	key_handler_t  handler;
-} scancode_routine_t;
+struct scancode_routine {
+	struct keyboard_key key;
+	key_handler_t       handler;
+};
 
 // Typedefs
 
@@ -54,7 +54,7 @@ typedef struct scancode_routine {
 // VARIABLES GLOBALES
 // ============================================================================
 
-extern scancode_routine_t current_layout[256];
+extern struct scancode_routine current_layout[256];
 
 // ============================================================================
 // EXTERNAL APIs

--- a/src/drivers/keyboard/layout.h
+++ b/src/drivers/keyboard/layout.h
@@ -15,9 +15,9 @@ static bool left_alt    = false;
 static bool num_lock    = false;
 static bool scroll_lock = false;
 
-static keyboard_key_t default_key_table[256];
+static struct keyboard_key default_key_table[256];
 
-static keyboard_key_t printable_keys[] = {
+static struct keyboard_key printable_keys[] = {
 
     // letters
     {'a', 'A', 0x1E, KEY_ALPHANUMERIC, LETTER, NULL},
@@ -85,7 +85,7 @@ static keyboard_key_t printable_keys[] = {
  * ---------------------------------------------------------------------------
  * Control Key group
  */
-static keyboard_key_t control_keys[] = {
+static struct keyboard_key control_keys[] = {
     // Press
     {UNDEFINED, UNDEFINED, 0x1D, KEY_CONTROL, PRESS, &left_ctrl},
     {UNDEFINED, UNDEFINED, 0x2A, KEY_CONTROL, PRESS, &left_shift},
@@ -128,9 +128,9 @@ typedef enum {
 	COLOR_INS    = VGA_COLOR(VGA_COLOR_BROWN, VGA_COLOR_WHITE),       // 0x52
 	COLOR_DEL    = VGA_COLOR(VGA_COLOR_RED, VGA_COLOR_YELLOW),        // 0x53
 	COLOR_NONE   = VGA_COLOR(VGA_COLOR_BLACK, VGA_COLOR_LIGHT_GREY)
-} nav_color_t;
+} nav_color;
 
-static keyboard_key_t navigation_keys[] = {
+static struct keyboard_key navigation_keys[] = {
     // Arrow keys
     {COLOR_UP, '8', 0x48, KEY_NAVIGATION, NUM_PAD, &num_lock},    // Pavé num 8 = Flèche Haut
     {COLOR_DOWN, '2', 0x50, KEY_NAVIGATION, NUM_PAD, &num_lock},  // Pavé num 2 = Flèche Bas
@@ -161,7 +161,7 @@ static keyboard_key_t navigation_keys[] = {
  * Function group
  */
 
-static keyboard_key_t function_keys[] = {
+static struct keyboard_key function_keys[] = {
     {0, UNDEFINED, 0x3B, KEY_FUNCTION, NONE, NULL},  // f1
     {1, UNDEFINED, 0x3C, KEY_FUNCTION, NONE, NULL},  // f2
     {2, UNDEFINED, 0x3D, KEY_FUNCTION, NONE, NULL},  // f3
@@ -184,7 +184,7 @@ static keyboard_key_t function_keys[] = {
  * Special group
  */
 
-static keyboard_key_t special_keys[] = {
+static struct keyboard_key special_keys[] = {
     {UNDEFINED, UNDEFINED, 0x0E, KEY_SPECIAL, BACKSPACE, NULL}, // BACKSPACE
     {UNDEFINED, UNDEFINED, 0x1C, KEY_SPECIAL, ENTER, NULL},     // ENTER
     {UNDEFINED, UNDEFINED, 0x01, KEY_SPECIAL, ESCAPE, NULL},    // ESCAPE
@@ -194,7 +194,7 @@ static keyboard_key_t special_keys[] = {
  * Special group
  *///-------------------------------------------------------------------------
 
-keyboard_key_t azerty_layout[] = {
+struct keyboard_key azerty_layout[] = {
     // Top Key
     {'&', '1', 0x02, KEY_ALPHANUMERIC, TOP_KEY, NULL},
     {'e', '2', 0x03, KEY_ALPHANUMERIC, TOP_KEY, NULL},

--- a/src/drivers/tty/tty.c
+++ b/src/drivers/tty/tty.c
@@ -7,8 +7,8 @@
 #include <memory/kmalloc.h>
 #include <memory/memory.h>
 
-TTY *current_tty;
-TTY  ttys[12];
+struct tty *current_tty;
+struct tty  ttys[12];
 
 static bool ft_strequ(const char *s1, const char *s2);
 static void print_help(void);
@@ -29,7 +29,8 @@ void tty_framebuffer_switch_color(uint8_t mode)
 void tty_framebuffer_clear(void)
 {
 	for (unsigned long i = 0; i < VGA_WIDTH * TTY_HIST_SIZE; i++)
-		current_tty->framebuffer[i] = (vga_entry){.character = 0x00, .mode = current_tty->mode};
+		current_tty->framebuffer[i] =
+		    (struct vga_entry){.character = 0x00, .mode = current_tty->mode};
 	current_tty->top_line_index = 0;
 	current_tty->cursor         = (struct s_cursor){0, 1};
 }
@@ -82,7 +83,7 @@ void tty_framebuffer_scroll_down(void)
 	for (size_t x = 0; x < VGA_WIDTH; x++) {
 		int offset = (bottom_line * VGA_WIDTH) + x;
 		current_tty->framebuffer[offset] =
-		    (vga_entry){.character = 0x00, .mode = current_tty->mode};
+		    (struct vga_entry){.character = 0x00, .mode = current_tty->mode};
 	}
 }
 
@@ -94,7 +95,7 @@ void tty_framebuffer_write(char c)
 		tty_history_disable();
 	uint8_t real_y = (uint8_t)current_tty->top_line_index + (uint8_t)current_tty->cursor.y;
 	int     offset = (real_y * VGA_WIDTH) + current_tty->cursor.x;
-	current_tty->framebuffer[offset] = (vga_entry){c, current_tty->mode};
+	current_tty->framebuffer[offset] = (struct vga_entry){c, current_tty->mode};
 }
 
 static bool ft_strequ(const char *s1, const char *s2)
@@ -149,7 +150,7 @@ void tty_cli_handle_nl(void)
 	ft_bzero(current_tty->cli, 256);
 }
 
-void tty_init(TTY *tty)
+void tty_init(struct tty *tty)
 {
 	tty->top_line_index        = 0;
 	tty->cursor                = (struct s_cursor){0, 1};
@@ -157,7 +158,7 @@ void tty_init(TTY *tty)
 	tty->history.top_line_save = 0;
 	tty->history.stop_scroll   = true;
 	tty->mode                  = VGA_DEFAULT_MODE;
-	tty->framebuffer_size      = (VGA_WIDTH * TTY_HIST_SIZE) * sizeof(vga_entry);
+	tty->framebuffer_size      = (VGA_WIDTH * TTY_HIST_SIZE) * sizeof(struct vga_entry);
 	tty->framebuffer           = NULL;
 	vga_enable_cursor(14, 15);
 	ft_bzero(tty->cli, 256);
@@ -165,12 +166,12 @@ void tty_init(TTY *tty)
 
 void ttys_init(void)
 {
-	for (unsigned long i = 0; i < sizeof(ttys) / sizeof(TTY); i++)
+	for (unsigned long i = 0; i < sizeof(ttys) / sizeof(struct tty); i++)
 		tty_init(ttys + i);
 	tty_switch(&ttys[0]);
 }
 
-void tty_load(TTY *tty)
+void tty_load(struct tty *tty)
 {
 	if (tty->framebuffer == NULL) {
 		tty->framebuffer = kmalloc(tty->framebuffer_size, (GFP_KERNEL | __GFP_ZERO));
@@ -182,7 +183,7 @@ void tty_load(TTY *tty)
 	vga_refresh_screen();
 }
 
-void tty_switch(TTY *tty)
+void tty_switch(struct tty *tty)
 {
 	current_tty = tty;
 	tty_load(tty);

--- a/src/drivers/vga/vga.c
+++ b/src/drivers/vga/vga.c
@@ -27,7 +27,7 @@
 #define KERN_DEFAULT ""
 #define KERN_CONT    "c"
 
-#define VGA_ENTRY_SIZE (VGA_WIDTH * VGA_HEIGHT) * sizeof(vga_entry)
+#define VGA_ENTRY_SIZE (VGA_WIDTH * VGA_HEIGHT) * sizeof(struct vga_entry)
 
 void vga_enable_cursor(uint8_t cursor_start, uint8_t cursor_end);
 
@@ -150,10 +150,10 @@ void vga_refresh_screen(void)
 		return;
 
 	for (int vga_y = 0; vga_y < VGA_HEIGHT; vga_y++) {
-		uint8_t    line_buffer = (uint8_t)current_tty->top_line_index + (uint8_t)vga_y;
-		vga_entry *src         = &current_tty->framebuffer[line_buffer * VGA_WIDTH];
-		vga_entry *dst         = VGA_ENTRY(0, vga_y);
-		ft_memcpy(dst, src, VGA_WIDTH * sizeof(vga_entry));
+		uint8_t           line_buffer = (uint8_t)current_tty->top_line_index + (uint8_t)vga_y;
+		struct vga_entry *src         = &current_tty->framebuffer[line_buffer * VGA_WIDTH];
+		struct vga_entry *dst         = VGA_ENTRY(0, vga_y);
+		ft_memcpy(dst, src, VGA_WIDTH * sizeof(struct vga_entry));
 	}
 	vga_set_cursor_position(current_tty->cursor.x, current_tty->cursor.y);
 }

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -1,10 +1,10 @@
-#include <arch/x86.h>
 #include <proc/exec.h>
 #include <proc/task.h>
 
+void init(void);
+
 void kernel_main(void)
 {
-
 	init();
 	exec_mok("cafe");
 	task_init_idle();

--- a/src/kernel/mb2_info.c
+++ b/src/kernel/mb2_info.c
@@ -4,7 +4,7 @@
 
 // Globals
 
-multiboot_info_t *mb2info = NULL;
+struct multiboot_info *mb2info = NULL;
 
 // Principal Header
 const struct multiboot_header mb2_header
@@ -35,11 +35,11 @@ const struct multiboot2_header_tag_end mb2_tag_end
 
 // Functions
 
-void mb2_mmap_iter(multiboot_tag_mmap_t *mmap, uint8_t *mmap_end, entry_handler_t handler,
+void mb2_mmap_iter(struct multiboot_tag_mmap *mmap, uint8_t *mmap_end, entry_handler_t handler,
                    bool free)
 {
-	for (multiboot_memory_map_t *entry = mmap->entries; (uint8_t *)entry < mmap_end;
-	     entry                         = next_entry(entry, mmap)) {
+	for (struct multiboot_mmap_entry *entry = mmap->entries; (uint8_t *)entry < mmap_end;
+	     entry                              = next_entry(entry, mmap)) {
 
 		if (entry->type != 1 && free == true)
 			continue;
@@ -62,13 +62,13 @@ void mb2_init(void)
 		kpanic("Invalid magic number: expected 0x%x | used 0x%x\n", MULTIBOOT2_BOOTLOADER_MAGIC,
 		       mb2_magic);
 	int tags_found            = 0;
-	mb2info                   = (multiboot_info_t *)mb2_mbi;
+	mb2info                   = (struct multiboot_info *)mb2_mbi;
 	struct multiboot_tag *tag = (struct multiboot_tag *)&mb2info->tags[0];
 
 	while (tag->type != MULTIBOOT_TAG_TYPE_END) {
 		switch (tag->type) {
 		case MULTIBOOT_TAG_TYPE_MMAP:
-			multiboot_tag_mmap_t *mmap = (multiboot_tag_mmap_t *)tag;
+			struct multiboot_tag_mmap *mmap = (struct multiboot_tag_mmap *)tag;
 			boot_allocator_init(mmap, (uint8_t *)mmap + mmap->size);
 			tags_found++;
 			break;

--- a/src/memory/boot_allocator.c
+++ b/src/memory/boot_allocator.c
@@ -10,8 +10,8 @@
 
 // Header
 
-static void     boot_allocator_sort_regions(region_t *reg, uint32_t count);
-static uint32_t boot_allocator_merge_contiguous_regions(region_t *reg, uint32_t count);
+static void     boot_allocator_sort_regions(struct region *reg, uint32_t count);
+static uint32_t boot_allocator_merge_contiguous_regions(struct region *reg, uint32_t count);
 
 // Defines
 
@@ -63,24 +63,24 @@ typedef struct boot_allocator {
 	uint32_t           num_allocations;
 	boot_alloc_entry_t allocations[MAX_REGIONS];
 	uint32_t           count[REGION_TYPE_COUNT];
-	region_t           regions[REGION_TYPE_COUNT][MAX_REGIONS];
+	struct region      regions[REGION_TYPE_COUNT][MAX_REGIONS];
 } boot_allocator_t;
 
-uint32_t free_count[MAX_ZONE];
-region_t free_zones[MAX_ZONE][MAX_REGIONS];
-uint32_t res_count[MAX_ZONE];
-region_t res_zones[MAX_ZONE][MAX_REGIONS];
+uint32_t      free_count[MAX_ZONE];
+struct region free_zones[MAX_ZONE][MAX_REGIONS];
+uint32_t      res_count[MAX_ZONE];
+struct region res_zones[MAX_ZONE][MAX_REGIONS];
 
 // Typedefs
 
-typedef void (*regions_foreach_fn)(region_t *regions);
+typedef void (*regions_foreach_fn)(struct region *regions);
 
 // ============================================================================
 // VARIABLES GLOBALES
 // ============================================================================
 
 extern boot_allocator_t bootmem;
-static region_t         all_reg_g[MAX_REGIONS * REGION_TYPE_COUNT];
+static struct region    all_reg_g[MAX_REGIONS * REGION_TYPE_COUNT];
 
 /*
  * The following APIs are used to store early allocations and to keep a track of every used memory
@@ -98,7 +98,7 @@ extern uint8_t   kernel_stack_top[];
 
 // Code
 
-static zone_type boot_alloc_get_addr_zone(uintptr_t addr)
+static enum zone_type boot_alloc_get_addr_zone(uintptr_t addr)
 {
 	if (addr >= HIGHMEM_START) {
 		return HIGHMEM_ZONE;
@@ -129,18 +129,18 @@ static void boot_allocator_add_region(boot_allocator_t *alloc, uintptr_t start, 
 	}
 
 	uint32_t index              = alloc->count[type];
-	alloc->regions[type][index] = (region_t){start, end};
+	alloc->regions[type][index] = (struct region){start, end};
 	alloc->count[type]++;
 }
-static void boot_allocator_add_to_zones(uint32_t count[MAX_ZONE],
-                                        region_t zones[MAX_ZONE][MAX_REGIONS], uint32_t size,
+static void boot_allocator_add_to_zones(uint32_t      count[MAX_ZONE],
+                                        struct region zones[MAX_ZONE][MAX_REGIONS], uint32_t size,
                                         uintptr_t start)
 {
-	zone_type zone = boot_alloc_get_addr_zone(start);
+	enum zone_type zone = boot_alloc_get_addr_zone(start);
 	if (count[zone] >= MAX_REGIONS) {
 		kpanic("No more space in zone %d to add a new region!", zone);
 	}
-	zones[zone][count[zone]++] = (region_t){start, start + size};
+	zones[zone][count[zone]++] = (struct region){start, start + size};
 	BOOT_ALLOCATOR_SORT_AND_MERGE(zones[zone], count[zone]);
 }
 
@@ -154,11 +154,11 @@ void boot_allocator_reserved_wrapper(uintptr_t start, uintptr_t end)
 	boot_allocator_add_region(&bootmem, start, end, RESERVED_MEMORY);
 }
 
-static void boot_allocator_sort_regions(region_t *reg, uint32_t count)
+static void boot_allocator_sort_regions(struct region *reg, uint32_t count)
 {
 	for (uint32_t i = 1; i < count; i++) {
-		region_t current = reg[i];
-		uint32_t j       = i + 1;
+		struct region current = reg[i];
+		uint32_t      j       = i + 1;
 
 		while (--j > 0 && reg[j - 1].start > current.start)
 			reg[j] = reg[j - 1];
@@ -170,7 +170,7 @@ static void boot_allocator_free_handler(uintptr_t start, uintptr_t end)
 {
 	uintptr_t cur = start;
 	for (uint32_t i = 0; i < BOOT_ALLOC_RESERVED_COUNT(&bootmem); i++) {
-		region_t res = BOOT_ALLOC_RESERVED_REGIONS(&bootmem)[i];
+		struct region res = BOOT_ALLOC_RESERVED_REGIONS(&bootmem)[i];
 
 		if (res.end <= cur || res.start >= end)
 			continue;
@@ -187,15 +187,15 @@ static void boot_allocator_free_handler(uintptr_t start, uintptr_t end)
 	}
 }
 
-static uint32_t boot_allocator_merge_contiguous_regions(region_t *reg, uint32_t count)
+static uint32_t boot_allocator_merge_contiguous_regions(struct region *reg, uint32_t count)
 {
-	region_t cur          = *reg;
-	uint32_t merged_count = 0;
-	region_t merged[MAX_REGIONS];
+	struct region cur          = *reg;
+	uint32_t      merged_count = 0;
+	struct region merged[MAX_REGIONS];
 
 	if (!count)
 		return count;
-	ft_bzero(merged, sizeof(region_t) * MAX_REGIONS);
+	ft_bzero(merged, sizeof(struct region) * MAX_REGIONS);
 	boot_allocator_sort_regions(reg, count);
 	for (uint32_t i = 1; i < count; i++) {
 		if (cur.end == reg[i].start) {
@@ -206,7 +206,7 @@ static uint32_t boot_allocator_merge_contiguous_regions(region_t *reg, uint32_t 
 		}
 	}
 	merged[merged_count++] = cur;
-	ft_memcpy(reg, merged, sizeof(region_t) * MAX_REGIONS);
+	ft_memcpy(reg, merged, sizeof(struct region) * MAX_REGIONS);
 	return merged_count;
 }
 
@@ -217,12 +217,12 @@ static uint32_t boot_allocator_merge_contiguous_regions(region_t *reg, uint32_t 
  * boot_allocator_print_inital_layout
  */
 
-static void boot_allocator_print_region_info(region_t *reg)
+static void boot_allocator_print_region_info(struct region *reg)
 {
 	vga_printf("%p -> %p\n", (void *)reg->start, (void *)reg->end);
 }
 
-static void boot_allocator_for_each_regions(regions_foreach_fn handler, region_t *reg,
+static void boot_allocator_for_each_regions(regions_foreach_fn handler, struct region *reg,
                                             uint32_t count)
 {
 	for (uint32_t i = 0; i < count; i++) {
@@ -230,13 +230,13 @@ static void boot_allocator_for_each_regions(regions_foreach_fn handler, region_t
 	}
 }
 
-static region_t *boot_allocator_get_all_regions(boot_allocator_t *alloc)
+static struct region *boot_allocator_get_all_regions(boot_allocator_t *alloc)
 {
 	uint32_t idx = 0;
 
 	for (uint32_t type = 0; type < REGION_TYPE_COUNT; type++) {
 		for (uint32_t i = 0; i < alloc->count[type]; i++) {
-			ft_memcpy(&all_reg_g[idx++], &alloc->regions[type][i], sizeof(region_t));
+			ft_memcpy(&all_reg_g[idx++], &alloc->regions[type][i], sizeof(struct region));
 		}
 	}
 	return all_reg_g;
@@ -251,7 +251,7 @@ static void boot_allocator_fill_gaps_as_holes(void)
 		return;
 	}
 
-	region_t *all_reg = boot_allocator_get_all_regions(&bootmem);
+	struct region *all_reg = boot_allocator_get_all_regions(&bootmem);
 
 	BOOT_ALLOCATOR_SORT_AND_MERGE(all_reg, total_reg);
 
@@ -281,7 +281,7 @@ static uint32_t boot_allocator_get_total_visibale_ram(boot_allocator_t *alloc)
 		kpanic("Error: %s: this function cannot be called before memory parsing\n", __func__);
 	}
 
-	region_t *all_reg = boot_allocator_get_all_regions(alloc);
+	struct region *all_reg = boot_allocator_get_all_regions(alloc);
 	BOOT_ALLOCATOR_SORT_AND_MERGE(all_reg, total_count);
 	uintptr_t end = all_reg[total_count - 1].end;
 	if (end == 0)
@@ -289,11 +289,12 @@ static uint32_t boot_allocator_get_total_visibale_ram(boot_allocator_t *alloc)
 	return end;
 }
 
-static void boot_allocator_init_zones(uint32_t zcount[MAX_ZONE],
-                                      region_t zones[MAX_ZONE][MAX_REGIONS], enum mem_type type)
+static void boot_allocator_init_zones(uint32_t      zcount[MAX_ZONE],
+                                      struct region zones[MAX_ZONE][MAX_REGIONS],
+                                      enum mem_type type)
 {
-	size_t    reg_count = boot_allocator_get_region_count(type);
-	region_t *reg       = boot_allocator_get_region(type);
+	size_t         reg_count = boot_allocator_get_region_count(type);
+	struct region *reg       = boot_allocator_get_region(type);
 
 	for (size_t i = 0; i < reg_count; i++) {
 		uintptr_t region_start = reg[i].start;
@@ -317,7 +318,7 @@ static void boot_allocator_init_zones(uint32_t zcount[MAX_ZONE],
 
 			uintptr_t sub_end = (region_end < zone_end) ? region_end : zone_end;
 			if (sub_end > cur_start) {
-				zones[zone][zcount[zone]++] = (region_t){cur_start, sub_end};
+				zones[zone][zcount[zone]++] = (struct region){cur_start, sub_end};
 			}
 			cur_start = sub_end;
 		}
@@ -326,15 +327,15 @@ static void boot_allocator_init_zones(uint32_t zcount[MAX_ZONE],
 
 // External APis
 
-region_t *boot_allocator_get_region(enum mem_type type) { return bootmem.regions[type]; }
+struct region *boot_allocator_get_region(enum mem_type type) { return bootmem.regions[type]; }
 
 uint32_t boot_allocator_get_region_count(enum mem_type type) { return bootmem.count[type]; }
 
-region_t *boot_allocator_get_free_zone(int type) { return free_zones[type]; }
+struct region *boot_allocator_get_free_zone(int type) { return free_zones[type]; }
 
 uint32_t boot_allocator_get_free_zones_count(int type) { return free_count[type]; }
 
-region_t *boot_allocator_get_res_zone(int type) { return res_zones[type]; }
+struct region *boot_allocator_get_res_zone(int type) { return res_zones[type]; }
 
 uint32_t boot_allocator_get_res_zones_count(int type) { return res_count[type]; }
 
@@ -346,8 +347,8 @@ void boot_allocator_freeze(void) { bootmem.state = FROZEN; }
 
 bool boot_allocator_range_overlaps(uintptr_t start, uintptr_t end, enum mem_type type)
 {
-	uint32_t  count   = bootmem.count[type];
-	region_t *regions = bootmem.regions[type];
+	uint32_t       count   = bootmem.count[type];
+	struct region *regions = bootmem.regions[type];
 
 	for (uint32_t i = 0; i < count; i++) {
 		if (!(end <= regions[i].start || start >= regions[i].end)) {
@@ -439,7 +440,7 @@ void boot_allocator_res_zones_printer(void)
 	vga_printf("------------------------------------------\n");
 }
 
-void boot_allocator_init(multiboot_tag_mmap_t *mmap, uint8_t *mmap_end)
+void boot_allocator_init(struct multiboot_tag_mmap *mmap, uint8_t *mmap_end)
 {
 	BOOT_ALLOC_FREE_COUNT(&bootmem)     = 0;
 	BOOT_ALLOC_RESERVED_COUNT(&bootmem) = 0;
@@ -448,8 +449,8 @@ void boot_allocator_init(multiboot_tag_mmap_t *mmap, uint8_t *mmap_end)
 	// Zone VGA/BIOS_ROM (0xa0000-0x100000)
 	boot_allocator_add_region(&bootmem, 0xa0000, 0x100000, RESERVED_MEMORY);
 	// Zone Low memory
-	const gdtr_t *gdtr = get_gdtr();
-	const idtr_t *idtr = get_idtr();
+	const struct gdtr *gdtr = get_gdtr();
+	const struct idtr *idtr = get_idtr();
 	boot_allocator_add_region(&bootmem, VIRT_TO_PHYS_LINEAR(gdtr->base),
 	                          VIRT_TO_PHYS_LINEAR(gdtr->base + gdtr->limit + 1), RESERVED_MEMORY);
 	boot_allocator_add_region(&bootmem, VIRT_TO_PHYS_LINEAR(idtr->base),
@@ -485,7 +486,7 @@ void boot_allocator_init(multiboot_tag_mmap_t *mmap, uint8_t *mmap_end)
 }
 
 // Be careful Only DMA/LOWMEM is USABLE otherwise you need to do a temporary mapping
-void *boot_alloc(uint32_t size, zone_type zone, bool freeable)
+void *boot_alloc(uint32_t size, enum zone_type zone, bool freeable)
 {
 	if (bootmem.state == FROZEN) {
 		vga_printf("Error: boot allocator is frozen\n");
@@ -493,8 +494,8 @@ void *boot_alloc(uint32_t size, zone_type zone, bool freeable)
 	}
 
 	for (int i = free_count[zone] - 1; i >= 0; i--) {
-		region_t *reg         = &free_zones[zone][i];
-		uint32_t  region_size = reg->end - reg->start;
+		struct region *reg         = &free_zones[zone][i];
+		uint32_t       region_size = reg->end - reg->start;
 
 		if (region_size >= size) {
 			if (reg->end - size < reg->start) {
@@ -521,8 +522,8 @@ void *boot_alloc(uint32_t size, zone_type zone, bool freeable)
 	return NULL;
 }
 
-void *boot_alloc_at(uint32_t size, zone_type zone, bool freeable, uintptr_t start, uintptr_t end,
-                    int align)
+void *boot_alloc_at(uint32_t size, enum zone_type zone, bool freeable, uintptr_t start,
+                    uintptr_t end, int align)
 {
 	if (bootmem.state == FROZEN || size == 0 || start + size > end) {
 		vga_printf("Error: %s: Invalid parameters or allocator frozen.\n", __func__);
@@ -530,7 +531,7 @@ void *boot_alloc_at(uint32_t size, zone_type zone, bool freeable, uintptr_t star
 	}
 
 	for (uint32_t i = 0; i < free_count[zone]; i++) {
-		region_t *reg = &free_zones[zone][i];
+		struct region *reg = &free_zones[zone][i];
 
 		if (reg->start >= end || reg->end <= start)
 			continue;
@@ -556,7 +557,7 @@ void *boot_alloc_at(uint32_t size, zone_type zone, bool freeable, uintptr_t star
 			if (alloc_end < original_reg_end) {
 				if (free_count[zone] >= MAX_REGIONS)
 					kpanic("No more space for free regions!");
-				free_zones[zone][free_count[zone]++] = (region_t){alloc_end, original_reg_end};
+				free_zones[zone][free_count[zone]++] = (struct region){alloc_end, original_reg_end};
 			}
 
 			reg->end = alloc_start;

--- a/src/memory/buddy.c
+++ b/src/memory/buddy.c
@@ -8,7 +8,7 @@
 #include <utils/kmacro.h>
 
 // Defines
-static const char *debug_buddy_zone_to_str(zone_type zone);
+static const char *debug_buddy_zone_to_str(enum zone_type zone);
 
 // Macros
 
@@ -19,7 +19,7 @@ static const char *debug_buddy_zone_to_str(zone_type zone);
 
 // VARIABLES GLOBALES
 
-static buddy_allocator_t buddy[MAX_ZONE];
+static struct buddy_allocator buddy[MAX_ZONE];
 
 // Internals APIs
 static const char *debug_buddy_order_to_string(int order)
@@ -56,15 +56,15 @@ static inline bool order_is_valid(int order) { return order >= 0 && order <= MAX
 
 static inline uintptr_t *page_node_to_phys(struct list_head *page_node)
 {
-	return (uintptr_t *)page_to_phys(container_of(page_node, page_t, node));
+	return (uintptr_t *)page_to_phys(container_of(page_node, struct page, node));
 }
 
-static inline struct list_head *order_to_free_list(size_t order, zone_type zone)
+static inline struct list_head *order_to_free_list(size_t order, enum zone_type zone)
 {
 	return &buddy[zone].areas[order].free_list[MIGRATE_MOVABLE];
 }
 
-static inline size_t order_to_nrFree(size_t order, zone_type zone)
+static inline size_t order_to_nrFree(size_t order, enum zone_type zone)
 {
 	return buddy[zone].areas[order].nr_free;
 }
@@ -97,7 +97,7 @@ static void pop_node(struct list_head *node)
 	node->prev       = NULL;
 }
 
-static uintptr_t *pop_first_block(size_t order, zone_type zone)
+static uintptr_t *pop_first_block(size_t order, enum zone_type zone)
 {
 	struct list_head *head        = order_to_free_list(order, zone);
 	struct list_head *first_block = head->next;
@@ -109,7 +109,7 @@ static uintptr_t *pop_first_block(size_t order, zone_type zone)
 	return page_node_to_phys(first_block);
 }
 
-static void set_block_metadata(page_t *first_page, size_t block_order, uint32_t state_flags)
+static void set_block_metadata(struct page *first_page, size_t block_order, uint32_t state_flags)
 {
 	size_t pages_in_block    = PAGE_BY_ORDER(block_order);
 	first_page->private_data = block_order;
@@ -123,7 +123,7 @@ static void set_block_metadata(page_t *first_page, size_t block_order, uint32_t 
 }
 
 static uintptr_t *split_block_to_order(size_t order_needed, size_t cur_order, uintptr_t *ptr,
-                                       zone_type zone)
+                                       enum zone_type zone)
 {
 	if (!order_is_valid(order_needed) || !order_is_valid(cur_order))
 		kpanic("Error: %s: Invalid Order\n", __func__);
@@ -134,8 +134,8 @@ static uintptr_t *split_block_to_order(size_t order_needed, size_t cur_order, ui
 	cur_order--;
 	size_t pages_by_block = PAGE_BY_ORDER(cur_order);
 
-	page_t *first_page      = page_addr_to_page((uintptr_t)ptr);
-	page_t *buddy_page_head = first_page + pages_by_block;
+	struct page *first_page      = page_addr_to_page((uintptr_t)ptr);
+	struct page *buddy_page_head = first_page + pages_by_block;
 
 	set_block_metadata(buddy_page_head, cur_order, PAGE_STATE_FREE);
 
@@ -145,7 +145,7 @@ static uintptr_t *split_block_to_order(size_t order_needed, size_t cur_order, ui
 	return split_block_to_order(order_needed, cur_order, ptr, zone);
 }
 
-static inline zone_type page_zone_flags_to_zone_type(uint32_t zone_flags)
+static inline enum zone_type page_zone_flags_to_zone_type(uint32_t zone_flags)
 {
 	switch (zone_flags) {
 	case PAGE_ZONE_DMA:
@@ -160,7 +160,7 @@ static inline zone_type page_zone_flags_to_zone_type(uint32_t zone_flags)
 }
 
 // Refactor
-static uintptr_t get_buddy_base(zone_type zone)
+static uintptr_t get_buddy_base(enum zone_type zone)
 {
 	switch (zone) {
 	case DMA_ZONE:
@@ -176,10 +176,10 @@ static uintptr_t get_buddy_base(zone_type zone)
 }
 
 // Refactor
-static page_t *get_buddy_page(void *block, size_t order, zone_type zone)
+static struct page *get_buddy_page(void *block, size_t order, enum zone_type zone)
 {
-	uintptr_t buddy_phys_addr = WHO_IS_MY_BUDDY((uintptr_t)block, order, get_buddy_base(zone));
-	page_t   *buddy_page      = page_addr_to_page(buddy_phys_addr);
+	uintptr_t    buddy_phys_addr = WHO_IS_MY_BUDDY((uintptr_t)block, order, get_buddy_base(zone));
+	struct page *buddy_page      = page_addr_to_page(buddy_phys_addr);
 
 	if (!buddy_page)
 		return NULL;
@@ -190,7 +190,7 @@ static page_t *get_buddy_page(void *block, size_t order, zone_type zone)
 
 // Externals APIs
 
-size_t buddy_print(zone_type zone)
+size_t buddy_print(enum zone_type zone)
 {
 	vga_printf("\n--- Buddy Free Blocks in Zone: %s ---\n", debug_buddy_zone_to_str(zone));
 
@@ -225,7 +225,7 @@ void buddy_print_summary(void)
 	size_t total_free_memory = 0;
 
 	for (int zone = 0; zone < MAX_ZONE; zone++) {
-		total_free_memory += buddy_print((zone_type)zone);
+		total_free_memory += buddy_print((enum zone_type)zone);
 	}
 
 	vga_printf("\n-------------------------------------------------------\n");
@@ -236,13 +236,13 @@ void buddy_print_summary(void)
 
 size_t buddy_get_var_size(void *var)
 {
-	page_t *page = page_addr_to_page((uintptr_t)var);
+	struct page *page = page_addr_to_page((uintptr_t)var);
 	if (PAGE_DATA_IS_MAGIC(page))
 		return 0;
 	return PAGE_BY_ORDER(page->private_data) * PAGE_SIZE;
 }
 
-uintptr_t *buddy_alloc_pages(size_t size, zone_type zone)
+uintptr_t *buddy_alloc_pages(size_t size, enum zone_type zone)
 {
 	size_t order_needed = size_to_order(size);
 	if (!order_is_valid(order_needed))
@@ -262,7 +262,7 @@ uintptr_t *buddy_alloc_pages(size_t size, zone_type zone)
 
 	void *ret = split_block_to_order(order_needed, cur_order, block, zone);
 
-	page_t *first_page = page_addr_to_page((uintptr_t)ret);
+	struct page *first_page = page_addr_to_page((uintptr_t)ret);
 	set_block_metadata(first_page, order_needed, PAGE_STATE_ALLOCATED);
 	return (uintptr_t *)ret;
 }
@@ -270,9 +270,9 @@ uintptr_t *buddy_alloc_pages(size_t size, zone_type zone)
 // TODO : Compound page
 void buddy_free_block(void *ptr)
 {
-	page_t  *page          = page_addr_to_page((uintptr_t)ptr);
-	size_t   block_order   = (size_t)page->private_data;
-	uint32_t current_state = PAGE_GET_STATE(page);
+	struct page *page          = page_addr_to_page((uintptr_t)ptr);
+	size_t       block_order   = (size_t)page->private_data;
+	uint32_t     current_state = PAGE_GET_STATE(page);
 
 	if (current_state == PAGE_STATE_FREE)
 		kpanic("Error: %s: Double free detected on address %p\n", __func__, ptr);
@@ -283,9 +283,9 @@ void buddy_free_block(void *ptr)
 		kpanic("Error: buddy_free_block: incorrect block order: %x\n", block_order);
 	}
 
-	zone_type zone = page_zone_flags_to_zone_type(PAGE_GET_ZONE(page));
+	enum zone_type zone = page_zone_flags_to_zone_type(PAGE_GET_ZONE(page));
 	while (block_order < MAX_ORDER) {
-		page_t *buddy_page = get_buddy_page(ptr, block_order, zone);
+		struct page *buddy_page = get_buddy_page(ptr, block_order, zone);
 		if (!buddy_page)
 			break;
 		pop_node(&buddy_page->node);
@@ -294,7 +294,7 @@ void buddy_free_block(void *ptr)
 		block_order++;
 	}
 
-	page_t *final_page = page_addr_to_page((uintptr_t)ptr);
+	struct page *final_page = page_addr_to_page((uintptr_t)ptr);
 
 	set_block_metadata(final_page, block_order, PAGE_STATE_FREE);
 	buddy_list_add_head(&final_page->node, order_to_free_list(block_order, zone));
@@ -312,7 +312,7 @@ void buddy_init(void)
 		}
 	}
 	for (uint32_t i = 0; i < total_pages; i++) {
-		page_t *page = &page_descriptors[i];
+		struct page *page = &page_descriptors[i];
 
 		if (PAGE_GET_STATE(page) == PAGE_STATE_AVAILABLE) {
 			page->private_data = 0;
@@ -324,7 +324,7 @@ void buddy_init(void)
 
 // DEBUG
 
-static const char *debug_buddy_zone_to_str(zone_type zone)
+static const char *debug_buddy_zone_to_str(enum zone_type zone)
 {
 	switch (zone) {
 	case 0:
@@ -356,7 +356,7 @@ static void debug_buddy_print_node_info(struct list_head *node)
 		vga_printf("        -> node->next->prev: %p (should be %p)\n", node->next->prev, node);
 }
 
-static void debug_buddy_corrupted_list(size_t order, zone_type zone)
+static void debug_buddy_corrupted_list(size_t order, enum zone_type zone)
 {
 	struct list_head *cur;
 	size_t            count = 0;
@@ -387,7 +387,7 @@ static void debug_buddy_corrupted_list(size_t order, zone_type zone)
 	}
 }
 
-static void print_buddy_free_list(size_t order, zone_type zone)
+static void print_buddy_free_list(size_t order, enum zone_type zone)
 {
 	struct list_head *head     = &buddy[zone].areas[order].free_list[MIGRATE_MOVABLE];
 	struct list_head *cur      = head->next;
@@ -407,10 +407,10 @@ static void print_buddy_free_list(size_t order, zone_type zone)
 // refactor
 static void debug_buddy_check_lost_pages(void)
 {
-	size_t    lost        = 0;
-	size_t    total_buddy = 0;
-	size_t    free_count  = boot_allocator_get_region_count(FREE_MEMORY);
-	region_t *free_reg    = boot_allocator_get_region(FREE_MEMORY);
+	size_t         lost        = 0;
+	size_t         total_buddy = 0;
+	size_t         free_count  = boot_allocator_get_region_count(FREE_MEMORY);
+	struct region *free_reg    = boot_allocator_get_region(FREE_MEMORY);
 
 	for (uint32_t i = 0; i < total_pages; i++) {
 		if (PAGE_IS_FREE(&page_descriptors[i])) {
@@ -438,7 +438,7 @@ static void debug_buddy_check_lost_pages(void)
 	}
 }
 
-static void debug_buddy_alloc_still_free(size_t order, void *phys, zone_type zone)
+static void debug_buddy_alloc_still_free(size_t order, void *phys, enum zone_type zone)
 {
 	struct list_head *head = order_to_free_list(order, zone);
 	for (struct list_head *cur = head->next; cur != head; cur = cur->next) {
@@ -451,12 +451,12 @@ static void debug_buddy_alloc_still_free(size_t order, void *phys, zone_type zon
 	}
 }
 
-static inline uintptr_t *alloc_block_with_order(size_t order, zone_type zone)
+static inline uintptr_t *alloc_block_with_order(size_t order, enum zone_type zone)
 {
 	return buddy_alloc_pages(PAGE_BY_ORDER(order) * PAGE_SIZE, zone);
 }
 
-static void buddy_drain_lower_orders(zone_type zone)
+static void buddy_drain_lower_orders(enum zone_type zone)
 {
 	for (int order = 0; order < MAX_ORDER; order++) {
 		while (buddy[zone].areas[order].nr_free > 0) {
@@ -475,7 +475,7 @@ static void buddy_drain_lower_orders(zone_type zone)
 	}
 }
 
-static void debug_buddy_simple_alloc(zone_type zone)
+static void debug_buddy_simple_alloc(enum zone_type zone)
 {
 	for (int i = MAX_ORDER; i >= 0; i--) {
 		if (order_to_nrFree(i, zone) > 0) {
@@ -485,13 +485,13 @@ static void debug_buddy_simple_alloc(zone_type zone)
 	}
 }
 
-static void debug_buddy_check_all_list_corrumption(zone_type zone)
+static void debug_buddy_check_all_list_corrumption(enum zone_type zone)
 {
 	for (size_t order = 0; order <= MAX_ORDER; order++)
 		debug_buddy_corrupted_list(order, zone);
 }
 
-static void debug_buddy_split_block(zone_type zone)
+static void debug_buddy_split_block(enum zone_type zone)
 {
 	buddy_drain_lower_orders(zone);
 	for (int order = MAX_ORDER - 1; order >= 0; order--) {
@@ -516,7 +516,7 @@ static void debug_buddy_split_block(zone_type zone)
 	}
 }
 
-static void debug_buddy_free_block(zone_type zone)
+static void debug_buddy_free_block(enum zone_type zone)
 {
 	buddy_drain_lower_orders(zone);
 

--- a/src/memory/kmalloc.c
+++ b/src/memory/kmalloc.c
@@ -36,7 +36,7 @@
 // INTERNAL APIs
 // ============================================================================
 
-void *get_allocation(zone_type zone, size_t size)
+void *get_allocation(enum zone_type zone, size_t size)
 {
 	void *ret = NULL;
 
@@ -49,7 +49,7 @@ void *get_allocation(zone_type zone, size_t size)
 	return ret;
 }
 
-void *try_alloc_with_reclaim(zone_type zone, size_t size)
+void *try_alloc_with_reclaim(enum zone_type zone, size_t size)
 {
 	void *alloc = get_allocation(zone, size);
 	if (alloc == NULL) {
@@ -68,12 +68,12 @@ size_t ksize(void *ptr)
 	if (!ptr)
 		return 0;
 
-	uintptr_t phys_addr  = VIRT_TO_PHYS_LINEAR(ptr);
-	page_t   *page       = page_addr_to_page(phys_addr);
-	size_t    page_state = PAGE_GET_STATE(page);
+	uintptr_t    phys_addr  = VIRT_TO_PHYS_LINEAR(ptr);
+	struct page *page       = page_addr_to_page(phys_addr);
+	size_t       page_state = PAGE_GET_STATE(page);
 
 	if (page_state == PAGE_STATE_SLAB) {
-		slab_t *slab = (slab_t *)page->private_data;
+		struct slab *slab = (struct slab *)page->private_data;
 		return slab->parent_cache->object_size;
 	} else if (page_state == PAGE_STATE_ALLOCATED) {
 		if (page->private_data == PAGE_MAGIC)
@@ -88,9 +88,9 @@ void kfree(void *ptr)
 {
 	if (!ptr)
 		return;
-	uintptr_t phys_addr  = VIRT_TO_PHYS_LINEAR(ptr);
-	page_t   *page       = page_addr_to_page(phys_addr);
-	size_t    page_state = PAGE_GET_STATE(page);
+	uintptr_t    phys_addr  = VIRT_TO_PHYS_LINEAR(ptr);
+	struct page *page       = page_addr_to_page(phys_addr);
+	size_t       page_state = PAGE_GET_STATE(page);
 	/* TODO: If an use after free of double free is done slab list become corrupt
 	 * For performance is better to do not handle the problem,
 	 * and give the responsability to the devloppeur
@@ -106,8 +106,8 @@ void kfree(void *ptr)
 void *kmalloc(size_t size, gfp_t flags)
 {
 
-	void     *ret  = NULL;
-	zone_type zone = LOWMEM_ZONE;
+	void          *ret  = NULL;
+	enum zone_type zone = LOWMEM_ZONE;
 	if (FLAG_IS_SET(flags, __GFP_DMA))
 		zone = DMA_ZONE;
 

--- a/src/memory/page.c
+++ b/src/memory/page.c
@@ -5,17 +5,17 @@
 #include <memory/memory.h>
 #include <memory/page.h>
 
-typedef void (*pages_foreach_fn)(page_t *page, void *data);
+typedef void (*pages_foreach_fn)(struct page *page, void *data);
 
-uint32_t reserved_count   = 0;
-uint32_t page_free_count  = 0;
-page_t  *page_descriptors = NULL;
+uint32_t     reserved_count   = 0;
+uint32_t     page_free_count  = 0;
+struct page *page_descriptors = NULL;
 
-static bool page_addr_is_in_reg(region_t *free_regions_in_zone, uint32_t region_count_in_zone,
+static bool page_addr_is_in_reg(struct region *free_regions_in_zone, uint32_t region_count_in_zone,
                                 uintptr_t addr)
 {
 	for (uint32_t i = 0; i < region_count_in_zone; i++) {
-		region_t *reg = &free_regions_in_zone[i];
+		struct region *reg = &free_regions_in_zone[i];
 		if (addr >= reg->start && addr < reg->end) {
 			return true;
 		}
@@ -27,10 +27,10 @@ static uint32_t page_get_state_flag(uintptr_t addr_start)
 {
 	for (int zone_idx = 0; zone_idx < MAX_ZONE; zone_idx++) {
 
-		uint32_t  free_count = boot_allocator_get_free_zones_count(zone_idx);
-		region_t *free_reg   = boot_allocator_get_free_zone(zone_idx);
-		uint32_t  res_count  = boot_allocator_get_res_zones_count(zone_idx);
-		region_t *res_reg    = boot_allocator_get_res_zone(zone_idx);
+		uint32_t       free_count = boot_allocator_get_free_zones_count(zone_idx);
+		struct region *free_reg   = boot_allocator_get_free_zone(zone_idx);
+		uint32_t       res_count  = boot_allocator_get_res_zones_count(zone_idx);
+		struct region *res_reg    = boot_allocator_get_res_zone(zone_idx);
 
 		if (page_addr_is_in_reg(free_reg, free_count, addr_start))
 			return (PAGE_STATE_AVAILABLE);
@@ -54,21 +54,21 @@ static inline uint32_t page_get_appropriate_flag(uintptr_t addr_start)
 	return page_get_state_flag(addr_start) | page_get_zone_flag(addr_start);
 }
 
-static void count_free_pages(page_t *page, void *counter)
+static void count_free_pages(struct page *page, void *counter)
 {
 	if (PAGE_IS_FREE(page))
 		(*(uint32_t *)counter)++;
 }
 
-static void count_reserved_pages(page_t *page, void *counter)
+static void count_reserved_pages(struct page *page, void *counter)
 {
 	if (!PAGE_IS_FREE(page))
 		(*(uint32_t *)counter)++;
 }
 
-static inline page_t *last_page() { return &page_descriptors[total_pages - 1]; }
+static inline struct page *last_page() { return &page_descriptors[total_pages - 1]; }
 
-static inline page_t *first_page() { return &page_descriptors[0]; }
+static inline struct page *first_page() { return &page_descriptors[0]; }
 
 static void page_descriptor_foreach(pages_foreach_fn handler, void *data)
 {
@@ -78,22 +78,22 @@ static void page_descriptor_foreach(pages_foreach_fn handler, void *data)
 
 // External Apis
 
-uint32_t page_to_index(page_t *page) { return page - page_descriptors; }
+uint32_t page_to_index(struct page *page) { return page - page_descriptors; }
 
-uintptr_t page_to_phys(page_t *page)
+uintptr_t page_to_phys(struct page *page)
 {
 	uint32_t idx = page_to_index(page);
 	return idx * PAGE_SIZE;
 }
 
-page_t *page_index_to_page(uint32_t idx)
+struct page *page_index_to_page(uint32_t idx)
 {
 	if (idx >= total_pages)
 		return NULL;
 	return &page_descriptors[idx];
 }
 
-page_t *page_addr_to_page(uintptr_t addr)
+struct page *page_addr_to_page(uintptr_t addr)
 {
 	return &page_descriptors[ALIGN_DOWN(addr, PAGE_SIZE) / PAGE_SIZE];
 }
@@ -103,7 +103,7 @@ bool page_addr_is_same_page(uintptr_t addr1, uintptr_t addr2)
 	return (addr1 / PAGE_SIZE) == (addr2 / PAGE_SIZE);
 }
 
-void page_print_info(page_t *page)
+void page_print_info(struct page *page)
 {
 	if (!page) {
 		vga_printf("page_print_info: Page pointer is NULL\n");
@@ -178,10 +178,10 @@ uint32_t page_get_updated_page_free_count(void)
 	return page_free_count;
 }
 
-page_t *page_addr_to_usable(uintptr_t addr, bool direction)
+struct page *page_addr_to_usable(uintptr_t addr, enum direction direction)
 {
-	int     factor = (direction == NEXT ? 1 : -1);
-	page_t *ret    = page_addr_to_page(addr);
+	int          factor = (direction == NEXT ? 1 : -1);
+	struct page *ret    = page_addr_to_page(addr);
 
 	while (ret >= first_page() && ret <= last_page()) {
 		if (PAGE_IS_FREE(ret))
@@ -198,11 +198,11 @@ uint32_t page_get_reserved_count(void) { return reserved_count; }
 
 void page_descriptor_init(void)
 {
-	uintptr_t p_addr = (uintptr_t)boot_alloc(MAX_PAGES * sizeof(page_t), LOWMEM_ZONE, TO_KEEP);
+	uintptr_t p_addr = (uintptr_t)boot_alloc(MAX_PAGES * sizeof(struct page), LOWMEM_ZONE, TO_KEEP);
 	if (!p_addr) {
 		kpanic("Failed to allocate page descriptors!");
 	}
-	page_descriptors = (page_t *)PHYS_TO_VIRT_LINEAR(p_addr);
+	page_descriptors = (struct page *)PHYS_TO_VIRT_LINEAR(p_addr);
 
 	for (uint32_t i = 0; i < MAX_PAGES; i++) {
 		page_descriptors[i].flags        = page_get_appropriate_flag(i * PAGE_SIZE);

--- a/src/memory/slab.c
+++ b/src/memory/slab.c
@@ -56,13 +56,13 @@ typedef enum {
 
 static const size_t cache_sizes[] = {8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096};
 
-static slab_cache_t slab_caches[MAX_ZONE][NUM_SLAB_CACHES];
+static struct slab_cache slab_caches[MAX_ZONE][NUM_SLAB_CACHES];
 
 // ============================================================================
 // INTERNAL APIs
 // ============================================================================
 
-static size_t slab_print_zone_summary(zone_type zone);
+static size_t slab_print_zone_summary(enum zone_type zone);
 static size_t list_count_nodes(struct list_head *head);
 
 static void list_add_head(struct list_head *new_node, struct list_head *head)
@@ -118,7 +118,7 @@ static cache_size size_to_cache_size(size_t size)
 	return cache_idx;
 }
 
-static void slab_init_intrusive_freelist(slab_t *src, void *first_obj, size_t obj_size,
+static void slab_init_intrusive_freelist(struct slab *src, void *first_obj, size_t obj_size,
                                          size_t available_space)
 {
 	char  *current       = (char *)first_obj;
@@ -133,19 +133,19 @@ static void slab_init_intrusive_freelist(slab_t *src, void *first_obj, size_t ob
 	src->freelist     = first_obj;
 }
 
-static slab_t *slab_create(slab_cache_t *cache, zone_type zone)
+static struct slab *slab_create(struct slab_cache *cache, enum zone_type zone)
 {
 	void *new_page_phy = buddy_alloc_pages(PAGE_SIZE, zone);
 	if (new_page_phy == NULL) {
 		return NULL;
 	}
-	page_t *page = page_addr_to_page((uintptr_t)new_page_phy);
+	struct page *page = page_addr_to_page((uintptr_t)new_page_phy);
 	PAGE_SET_STATE(page, PAGE_STATE_SLAB);
 
-	slab_t *ret;
-	void   *first_object;
-	size_t  available_space;
-	void   *new_page_virt = PHYS_TO_VIRT_LINEAR(new_page_phy);
+	struct slab *ret;
+	void        *first_object;
+	size_t       available_space;
+	void        *new_page_virt = PHYS_TO_VIRT_LINEAR(new_page_phy);
 	if (SLAB_IS_EXTERNAL(cache->object_size)) {
 		gfp_t flags = GFP_KERNEL; // Start with the basic flags
 		if (zone == DMA_ZONE)
@@ -155,7 +155,7 @@ static slab_t *slab_create(slab_cache_t *cache, zone_type zone)
 		 * multi-core (SMP) architecture, concurrency can create race conditions or at least
 		 * deadlocks.
 		 */
-		ret = kmalloc(sizeof(slab_t), flags);
+		ret = kmalloc(sizeof(struct slab), flags);
 		if (!ret) {
 			buddy_free_block(new_page_phy);
 			return NULL;
@@ -164,9 +164,9 @@ static slab_t *slab_create(slab_cache_t *cache, zone_type zone)
 		available_space = PAGE_SIZE;
 
 	} else {
-		ret             = (slab_t *)new_page_virt;
-		first_object    = (void *)((uintptr_t)new_page_virt + sizeof(slab_t));
-		available_space = PAGE_SIZE - sizeof(slab_t);
+		ret             = (struct slab *)new_page_virt;
+		first_object    = (void *)((uintptr_t)new_page_virt + sizeof(struct slab));
+		available_space = PAGE_SIZE - sizeof(struct slab);
 	}
 
 	ret->inuse        = 0;
@@ -180,22 +180,22 @@ static slab_t *slab_create(slab_cache_t *cache, zone_type zone)
 // EXTERNAL APIs
 // ============================================================================
 
-void slab_shrink_caches(zone_type zone)
+void slab_shrink_caches(enum zone_type zone)
 {
 	for (size_t i = 0; i < NUM_SLAB_CACHES; i++) {
-		slab_cache_t *cache = &slab_caches[zone][i];
+		struct slab_cache *cache = &slab_caches[zone][i];
 		if (cache->slabs_empty.next == &cache->slabs_empty)
 			continue;
 		struct list_head *head       = &cache->slabs_empty;
 		struct list_head *empty_list = head->next;
 		while (empty_list != head) {
 			struct list_head *next = empty_list->next;
-			slab_t           *slab = container_of(empty_list, slab_t, list);
+			struct slab      *slab = container_of(empty_list, struct slab, list);
 
 			void *phys_addr_in_page =
 			    (void *)(SLAB_IS_EXTERNAL(cache->object_size) ? VIRT_TO_PHYS_LINEAR(slab->freelist)
 			                                                  : VIRT_TO_PHYS_LINEAR(slab));
-			page_t *page = page_addr_to_page((uintptr_t)phys_addr_in_page);
+			struct page *page = page_addr_to_page((uintptr_t)phys_addr_in_page);
 			PAGE_SET_STATE(page, PAGE_STATE_ALLOCATED);
 			page->private_data = 0;
 			buddy_free_block((void *)page_to_phys(page));
@@ -208,11 +208,11 @@ void slab_shrink_caches(zone_type zone)
 
 void slab_free(void *ptr)
 {
-	page_t *page = page_addr_to_page((uintptr_t)VIRT_TO_PHYS_LINEAR(ptr));
+	struct page *page = page_addr_to_page((uintptr_t)VIRT_TO_PHYS_LINEAR(ptr));
 	if (PAGE_GET_STATE(page) != PAGE_STATE_SLAB)
 		kpanic("Error: %s: try to free memory not handled by slab.\n", __func__);
-	slab_t       *slab  = (slab_t *)page->private_data;
-	slab_cache_t *cache = slab->parent_cache;
+	struct slab       *slab  = (struct slab *)page->private_data;
+	struct slab_cache *cache = slab->parent_cache;
 
 	char *obj      = ptr;
 	*(void **)obj  = slab->freelist;
@@ -227,20 +227,20 @@ void slab_free(void *ptr)
 	}
 }
 
-void *slab_alloc(size_t size, zone_type zone)
+void *slab_alloc(size_t size, enum zone_type zone)
 {
 
 	cache_size slab_size = size_to_cache_size(size);
 	if (slab_size == NUM_SLAB_CACHES || zone > DMA_ZONE)
 		return NULL;
 
-	slab_cache_t *cache = &slab_caches[zone][slab_size];
-	slab_t       *slab;
+	struct slab_cache *cache = &slab_caches[zone][slab_size];
+	struct slab       *slab;
 
 	if (!list_is_empty(&cache->slabs_partial))
-		slab = container_of(list_first_entry(&cache->slabs_partial), slab_t, list);
+		slab = container_of(list_first_entry(&cache->slabs_partial), struct slab, list);
 	else if (!list_is_empty(&cache->slabs_empty)) {
-		slab = container_of(list_first_entry(&cache->slabs_empty), slab_t, list);
+		slab = container_of(list_first_entry(&cache->slabs_empty), struct slab, list);
 		pop_node(&slab->list);
 		list_add_head(&slab->list, &cache->slabs_partial);
 	} else {
@@ -271,7 +271,7 @@ void slab_init(void)
 			INIT_SENTINEL(empty, &slab_caches[zone][i].slabs_empty);
 			slab_caches[zone][i].object_size = cache_sizes[i];
 			slab_caches[zone][i].objects_per_slab =
-			    (SLAB_IS_EXTERNAL(cache_sizes[i]) ? PAGE_SIZE : PAGE_SIZE - sizeof(slab_t)) /
+			    (SLAB_IS_EXTERNAL(cache_sizes[i]) ? PAGE_SIZE : PAGE_SIZE - sizeof(struct slab)) /
 			    cache_sizes[i];
 		}
 	}
@@ -317,7 +317,7 @@ static const char *debug_slab_size_to_str(cache_size size)
 	}
 }
 
-static size_t slab_print_zone_summary(zone_type zone)
+static size_t slab_print_zone_summary(enum zone_type zone)
 {
 	vga_printf("\n--- Slab Caches in Zone: %s ---\n", (zone == DMA_ZONE) ? "DMA" : "LOWMEM");
 
@@ -325,7 +325,7 @@ static size_t slab_print_zone_summary(zone_type zone)
 	bool   has_active_caches   = false;
 
 	for (int i = 0; i < NUM_SLAB_CACHES; i++) {
-		slab_cache_t *cache = &slab_caches[zone][i];
+		struct slab_cache *cache = &slab_caches[zone][i];
 
 		size_t full_slabs    = list_count_nodes(&cache->slabs_full);
 		size_t partial_slabs = list_count_nodes(&cache->slabs_partial);
@@ -344,7 +344,7 @@ static size_t slab_print_zone_summary(zone_type zone)
 		struct list_head *iter;
 		total_inuse += full_slabs * cache->objects_per_slab;
 		for (iter = cache->slabs_partial.next; iter != &cache->slabs_partial; iter = iter->next) {
-			slab_t *s = container_of(iter, slab_t, list);
+			struct slab *s = container_of(iter, struct slab, list);
 			total_inuse += s->inuse;
 		}
 
@@ -378,7 +378,7 @@ void slab_print_summary(void)
 	for (int zone = 0; zone < MAX_ZONE; zone++) {
 		if (zone >= DMA_ZONE + 1)
 			continue;
-		total_mem_held += slab_print_zone_summary((zone_type)zone);
+		total_mem_held += slab_print_zone_summary((enum zone_type)zone);
 	}
 
 	vga_printf("\n------------------------------------------------------------\n");

--- a/src/memory/vmalloc.c
+++ b/src/memory/vmalloc.c
@@ -58,7 +58,7 @@ typedef struct vm_area {
 
 static struct list_head vmalloc_areas;
 
-static const zone_type vmalloc_zonelist[] = {HIGHMEM_ZONE, LOWMEM_ZONE, INVALID_ZONE};
+static const enum zone_type vmalloc_zonelist[] = {HIGHMEM_ZONE, LOWMEM_ZONE, INVALID_ZONE};
 
 // ============================================================================
 // INTERNAL APIs

--- a/src/memory/vmm.c
+++ b/src/memory/vmm.c
@@ -28,7 +28,7 @@ uintptr_t kpage_dir = 0;
 
 // External APIs
 
-void page_fault_handler(trap_frame_t *frame)
+void page_fault_handler(struct trap_frame *frame)
 {
 	uint32_t faulting_address;
 

--- a/src/proc/exec.c
+++ b/src/proc/exec.c
@@ -50,7 +50,7 @@ void exec_task(struct task *task, bool userspace)
 
 int exec_fn(void *fn_start, size_t fn_size, char *fn_name, bool userspace)
 {
-	section_t text;
+	struct section text;
 
 	// vaddr and flags are overwritten after by userspace_get_new
 	if (!section_init_from_buffer(&text, 0, fn_start, fn_size, 0))

--- a/src/proc/section.c
+++ b/src/proc/section.c
@@ -3,10 +3,10 @@
 #include <memory/kmalloc.h>
 #include <proc/section.h>
 
-static ssize_t fake_read(io_stream_t *stream, void *dest, size_t size)
+static ssize_t fake_read(struct io_stream *stream, void *dest, size_t size)
 {
-	section_t *ctx        = (section_t *)stream->ctx;
-	size_t     bytes_read = 0;
+	struct section *ctx        = (struct section *)stream->ctx;
+	size_t          bytes_read = 0;
 
 	if (!ctx || !ctx->data_start || !dest)
 		return -1;
@@ -28,12 +28,12 @@ static ssize_t fake_read(io_stream_t *stream, void *dest, size_t size)
 	return bytes_read;
 }
 
-io_stream_t *section_create_reader(section_t *sec)
+struct io_stream *section_create_reader(struct section *sec)
 {
 	if (!sec || !sec->data_start || sec->data_size == 0)
 		return NULL;
 
-	io_stream_t *stream = io_stream_get_new((void *)sec, sec->data_size, 0);
+	struct io_stream *stream = io_stream_get_new((void *)sec, sec->data_size, 0);
 	if (!stream)
 		return NULL;
 
@@ -46,8 +46,8 @@ io_stream_t *section_create_reader(section_t *sec)
 	return stream;
 }
 
-bool section_init_from_buffer(section_t *sec, uintptr_t v_addr, const void *start, uint32_t size,
-                              uint32_t flags)
+bool section_init_from_buffer(struct section *sec, uintptr_t v_addr, const void *start,
+                              uint32_t size, uint32_t flags)
 {
 	if (!sec || !start || size == 0)
 		return false;

--- a/src/proc/task.c
+++ b/src/proc/task.c
@@ -48,7 +48,7 @@ static const char *task_state_to_string(enum process_states state)
 	return "UNKNOWN";
 }
 
-static void task_print_section(const char *label, const section_t *sec)
+static void task_print_section(const char *label, const struct section *sec)
 {
 	if (!sec) {
 		vga_printf("  - %s: (null)\n", label);
@@ -74,7 +74,7 @@ struct task *task_get_current_task(void) { return current_task; }
 
 // text and data are used as templates; this function allocates its own internal sections
 // After return, the caller must free the input text and data if they were heap-allocated
-struct task *task_get_new(char *name, bool userspace, section_t *text, section_t *data)
+struct task *task_get_new(char *name, bool userspace, struct section *text, struct section *data)
 {
 	if (!name)
 		return NULL;
@@ -87,21 +87,23 @@ struct task *task_get_new(char *name, bool userspace, section_t *text, section_t
 		return NULL;
 
 	// kmalloc use slabs caches here
-	char *memory_zone = kmalloc(sizeof(struct task) + name_len + 1 + (sizeof(section_t) * 4),
+	char *memory_zone = kmalloc(sizeof(struct task) + name_len + 1 + (sizeof(struct section) * 4),
 	                            GFP_KERNEL | __GFP_ZERO);
 	if (!memory_zone)
 		return NULL;
 
 	struct task *ret = (struct task *)memory_zone;
 
-	ret->text_sec  = (section_t *)(memory_zone + sizeof(struct task));
-	ret->data_sec  = (section_t *)(memory_zone + sizeof(struct task) + sizeof(section_t));
-	ret->stack_sec = (section_t *)(memory_zone + sizeof(struct task) + sizeof(section_t) * 2);
-	ret->heap_sec  = (section_t *)(memory_zone + sizeof(struct task) + sizeof(section_t) * 3);
+	ret->text_sec = (struct section *)(memory_zone + sizeof(struct task));
+	ret->data_sec = (struct section *)(memory_zone + sizeof(struct task) + sizeof(struct section));
+	ret->stack_sec =
+	    (struct section *)(memory_zone + sizeof(struct task) + sizeof(struct section) * 2);
+	ret->heap_sec =
+	    (struct section *)(memory_zone + sizeof(struct task) + sizeof(struct section) * 3);
 	if (text)
-		ft_memcpy(ret->text_sec, text, sizeof(section_t));
+		ft_memcpy(ret->text_sec, text, sizeof(struct section));
 	if (data)
-		ft_memcpy(ret->data_sec, data, sizeof(section_t));
+		ft_memcpy(ret->data_sec, data, sizeof(struct section));
 
 	ret->pid = id_manager_alloc(pid_manager);
 	if (ret->pid == -1)
@@ -138,7 +140,7 @@ struct task *task_get_new(char *name, bool userspace, section_t *text, section_t
 
 	ret->state = TASK_NEW;
 
-	ret->name = memory_zone + sizeof(struct task) + sizeof(section_t) * 4;
+	ret->name = memory_zone + sizeof(struct task) + sizeof(struct section) * 4;
 	ft_memcpy(ret->name, name, name_len);
 	ret->name[name_len] = 0;
 

--- a/src/proc/userspace.c
+++ b/src/proc/userspace.c
@@ -6,9 +6,9 @@
 #include <proc/section.h>
 #include <proc/userspace.h>
 
-static inline void init_heap_section(section_t *prev, section_t *heap)
+static inline void init_heap_section(struct section *prev, struct section *heap)
 {
-	ft_bzero(heap, sizeof(section_t));
+	ft_bzero(heap, sizeof(struct section));
 	heap->v_addr       = get_next_section_start_after_page_guard(prev->v_addr, prev->mapping_size);
 	heap->data_start   = 0;
 	heap->data_size    = 0;
@@ -16,9 +16,9 @@ static inline void init_heap_section(section_t *prev, section_t *heap)
 	heap->flags        = USER_SECTION_RW;
 }
 
-static inline void init_stack_section(section_t *stack)
+static inline void init_stack_section(struct section *stack)
 {
-	ft_bzero(stack, sizeof(section_t));
+	ft_bzero(stack, sizeof(struct section));
 	stack->v_addr       = get_prev_section_start(USER_STACK_START, DEFAULT_STACK_SIZE);
 	stack->data_start   = 0;
 	stack->data_size    = 0;
@@ -40,7 +40,7 @@ static bool userspace_map_kernel(uint32_t uspace_pd_phy)
 	return true;
 }
 
-static bool map_section(uintptr_t uspace_pd_phy, section_t *to_map)
+static bool map_section(uintptr_t uspace_pd_phy, struct section *to_map)
 {
 	if (!to_map || to_map->mapping_size == 0)
 		return true;
@@ -51,7 +51,7 @@ static bool map_section(uintptr_t uspace_pd_phy, section_t *to_map)
 	if (!p_pool_addr)
 		return false;
 
-	io_stream_t *stream = NULL;
+	struct io_stream *stream = NULL;
 	if (to_map->data_start && to_map->data_size > 0)
 		stream = section_create_reader(to_map);
 
@@ -87,8 +87,8 @@ bad:
 
 bool userspace_create_new(struct task *new_task)
 {
-	section_t *text = task_text(new_task);
-	section_t *data = task_data(new_task);
+	struct section *text = task_text(new_task);
+	struct section *data = task_data(new_task);
 	// Section Text
 	if (!text || text->data_size == 0)
 		return false;
@@ -110,11 +110,12 @@ bool userspace_create_new(struct task *new_task)
 	}
 
 	// Section Heap
-	section_t *last_sec = (data && data->data_size > 0) ? task_data(new_task) : task_text(new_task);
+	struct section *last_sec =
+	    (data && data->data_size > 0) ? task_data(new_task) : task_text(new_task);
 	init_heap_section(last_sec, task_heap(new_task));
 
 	// Section Stack
-	section_t *stack = task_stack(new_task);
+	struct section *stack = task_stack(new_task);
 	init_stack_section(stack);
 
 	// Page Directory
@@ -153,7 +154,7 @@ bad:
 // DEBUG APIs
 // ============================================================================
 
-static void print_section_info(const char *label, const section_t *sec)
+static void print_section_info(const char *label, const struct section *sec)
 {
 	if (!sec || (!sec->v_addr && !sec->mapping_size)) {
 		vga_printf("  [%s] (not mapped)\n", label);


### PR DESCRIPTION
- Convert all struct typedefs to explicit 'struct' keyword usage
- Convert all enum typedefs to explicit 'enum' keyword usage
- Retain function pointer typedefs as they are still useful
- Update all usages across the codebase to use new syntax
- Remove unnecessary forward declarations

Changes touch architecture headers, drivers, memory subsystem,
and process management code. Kernel compiles successfully.
