### PR TITLE
fix fork

### DIFF
--- a/include/arch/trap_frame.h
+++ b/include/arch/trap_frame.h
@@ -2,6 +2,7 @@
 
 #include <arch/register.h>
 #include <types.h>
+#include <utils/assert.h>
 
 struct trap_frame {
 	struct registers regs;
@@ -16,3 +17,7 @@ struct trap_frame {
 	uint32_t user_esp;
 	uint32_t user_ss;
 } __packed;
+
+// See `src/arch/x86/irq.s`
+static_assert(offsetof(struct trap_frame, int_no) == 48,
+              "Offset of `int_no` in `struct trap_frame` must be 48.");

--- a/include/list.h
+++ b/include/list.h
@@ -17,7 +17,7 @@ struct list_head {
 
 #define list_is_empty(head) ((head) == (head)->next)
 
-#define list_entry(ptr, type, member) container_of(ptr, type, member)
+#define list_entry container_of
 
 #define list_next_entry(pos, member) list_entry((pos)->member.next, typeof(*(pos)), member)
 

--- a/include/memory/vmm.h
+++ b/include/memory/vmm.h
@@ -92,10 +92,11 @@ enum Page_Directory_Entry {
 
 // Macros
 
-#define GET_PDE_INDEX(vaddr)    ((vaddr) >> 22)
-#define GET_PTE_INDEX(vaddr)    (((vaddr) >> 12) & 0x3FF)
+#define GET_PDE_INDEX(vaddr)    ((uintptr_t)(vaddr) >> 22)
+#define GET_PTE_INDEX(vaddr)    (((uintptr_t)(vaddr) >> 12) & 0x3FF)
 #define ENTRY_FLAGS_MASK        (0xFFF)
-#define GET_ENTRY_ADDR(entry)   ((entry) & ~ENTRY_FLAGS_MASK)
+#define GET_ENTRY_FLAGS(entry)  ((uintptr_t)(entry) & ENTRY_FLAGS_MASK)
+#define GET_ENTRY_ADDR(entry)   ((uintptr_t)(entry) & ~ENTRY_FLAGS_MASK)
 #define GET_PD_RANGE_SIZE(size) (DIV_ROUND_UP(ALIGN(size, PAGE_SIZE), 1024 * PAGE_SIZE))
 
 // STRUCT

--- a/include/proc/task.h
+++ b/include/proc/task.h
@@ -112,4 +112,5 @@ struct task *task_get_kitoxD(void);
 struct task *task_find_by_pid(pid_t pid);
 struct task *task_get_new(const char *name, size_t ring, struct section *text,
                           struct section *data);
+struct task *task_clone(const struct task *task);
 void         sloppy_exec(char *sloppy_name);

--- a/include/proc/task.h
+++ b/include/proc/task.h
@@ -94,7 +94,8 @@ static __always_inline bool task_has_child_pid(struct task *parent, pid_t child_
 	return false;
 }
 
-void         task_print_info(SHELL_ARGS);
+void         task_print_info(struct task *task);
+void         task_cmd_print_info(SHELL_ARGS);
 void         task_print_stack(const struct task *task);
 void         task_append_child(struct task *parent, struct task *child);
 void         task_init_process(void);
@@ -109,6 +110,6 @@ struct task *task_get_idle(void);
 struct task *task_get_dummy(void);
 struct task *task_get_kitoxD(void);
 struct task *task_find_by_pid(pid_t pid);
-struct task *task_get_new(const char *name, bool userspace, struct section *text,
+struct task *task_get_new(const char *name, size_t ring, struct section *text,
                           struct section *data);
 void         sloppy_exec(char *sloppy_name);

--- a/linker.ld
+++ b/linker.ld
@@ -8,6 +8,7 @@ SECTIONS {
     }
 
 	. += 0xC0000000;
+
     PROVIDE(kernel_start = .);
 
     .text ALIGN(4K) : AT(ADDR(.text) - 0xC0000000) {
@@ -33,10 +34,12 @@ SECTIONS {
         *(COMMON)
         *(.bss)
     }
+
     .stack ALIGN(16) : AT(ADDR(.stack) - 0xC0000000) {
         kernel_stack = .;
         *(.stack)
         kernel_stack_top = .;
     }
+
     PROVIDE(kernel_end = .);
 }

--- a/src/drivers/tty/tty.c
+++ b/src/drivers/tty/tty.c
@@ -149,7 +149,7 @@ struct shell_command shell_commands[] = {
     {"fibo", "Run the mok process: fibo.", exec_mok_fibo},
     {"hello", "Run the mok process: hello.", exec_mok_hello},
     {"pid", "Run the mok process: pid.", exec_mok_pid},
-    {"task_info", "Print task data using pid.", task_print_info},
+    {"task_info", "Print task data using pid.", task_cmd_print_info},
     {"kill", "Send signal to process .", sys_kill_wrapper},
     {"help", "Print this help message.", print_help}};
 

--- a/src/drivers/vga/vga.c
+++ b/src/drivers/vga/vga.c
@@ -38,9 +38,9 @@ void vga_enable_cursor(uint8_t cursor_start, uint8_t cursor_end);
 
 static int ft_putchar(char c)
 {
-	// #ifndef NDEBUG
+#ifndef NDEBUG
 	outb(0x3f8, c);
-	// #endif
+#endif
 
 	switch (c) {
 	case '\n':

--- a/src/drivers/vga/vga.c
+++ b/src/drivers/vga/vga.c
@@ -34,6 +34,10 @@ void vga_enable_cursor(uint8_t cursor_start, uint8_t cursor_end);
 
 static int ft_putchar(char c)
 {
+	// #ifndef NDEBUG
+	outb(0x3f8, c);
+	// #endif
+
 	switch (c) {
 	case '\n':
 		current_tty->cursor.y++;

--- a/src/drivers/vga/vga.c
+++ b/src/drivers/vga/vga.c
@@ -5,6 +5,10 @@
 #include <stdarg.h>
 #include <utils/kmacro.h>
 
+#ifndef NDEBUG
+# include <proc/task.h>
+#endif
+
 #define KERNEL_BANNER                                                                              \
 	"\n"                                                                                           \
 	"  /$$   /$$   /$$   /$$               /$$   /$$\n"                                            \
@@ -197,6 +201,24 @@ void vga_printf(const char *fmt, ...)
 			case 'c':
 				ft_putchar(va_arg(ap, uint32_t));
 				break;
+
+#ifndef NDEBUG
+			case 't': {
+				struct task *task = va_arg(ap, struct task *);
+				ft_putstr("task<");
+				if (task) {
+					ft_puthexa((uintptr_t)task, false, true);
+					ft_putstr(",name=\"");
+					ft_putstr(task->name);
+					ft_putstr("\",pid=");
+					ft_putnbr(task->pid);
+				} else {
+					ft_putstr("null");
+				}
+				ft_putchar('>');
+				break;
+			}
+#endif
 
 			case '%':
 				ft_putchar('%');

--- a/src/memory/vmm.c
+++ b/src/memory/vmm.c
@@ -7,6 +7,7 @@
 #include <memory/vma.h>
 #include <memory/vmm.h>
 #include <proc/task.h>
+#include <utils/kmacro.h>
 
 /*
  * Virtual-to-physical address translation (32-bit paging):
@@ -26,29 +27,98 @@
 
 uintptr_t kpage_dir = 0;
 
-// Internal APIs
-
-// External APIs
+enum PageFaultCauses {
+	PFC_PRESENT       = 1 << 0,
+	PFC_WRITE         = 1 << 1,
+	PFC_USER          = 1 << 2,
+	PFC_RESERVED      = 1 << 3,
+	PFC_INSTR_FETCH   = 1 << 4,
+	PFC_PROT_KEY      = 1 << 5,
+	PFC_SSTACK        = 1 << 6,
+	PFC_SOFT_GUARD_EX = 1 << 15,
+};
 
 void page_fault_handler(struct trap_frame *frame)
 {
-	uint32_t faulting_address;
+#define caused_by(cause) FLAG_IS_SET(frame->err_code, cause)
 
+	void *faulting_address;
 	__asm__ volatile("mov %%cr2, %0" : "=r"(faulting_address));
 
 	struct task    *cur_task   = task_get_current_task();
-	struct vm_area *fault_area = vma_find_by_addr((void *)faulting_address, &cur_task->vma_areas);
+	struct vm_area *fault_area = vma_find_by_addr(faulting_address, &cur_task->vma_areas);
+
 	if (fault_area && fault_area->state == VM_AREA_LAZY) {
 		if (!vma_map_area(fault_area, cur_task->cr3))
 			kpanic("Failed to map lazy VM area");
 		fault_area->state = VM_AREA_ALLOCATED;
-	} else {
-		vga_printf("Faulting address: 0x%x\n", faulting_address);
-		vga_printf("Error code: 0x%x\n", frame->err_code);
-		vga_printf("Cause: %s\n",
-		           (frame->err_code & 1) ? "Protection violation" : "Page not present");
-		kpanic("Page fault");
+		return;
 	}
+
+#ifndef NDEBUG
+
+	vga_printf("\n   === PAGE FAULT ===\n");
+	vga_printf("Faulting address: %p\n", faulting_address);
+	vga_printf("Instr. Pointer:   %p\n", frame->eip);
+	vga_printf("Page Directory:   %p\n", cur_task->cr3);
+	vga_printf("Page Dir. Index:  %d (+%p)\n", GET_PDE_INDEX(faulting_address),
+	           GET_PDE_INDEX(faulting_address) * sizeof(uint32_t));
+	vga_printf("Page Table:       %p\n", GET_ENTRY_ADDR(((uint32_t *)PHYS_TO_VIRT_LINEAR(
+	                                         cur_task->cr3))[GET_PDE_INDEX(faulting_address)]));
+	vga_printf("Page Table Index: %d (+%p)\n", GET_PTE_INDEX(faulting_address),
+	           GET_PTE_INDEX(faulting_address) * sizeof(uint32_t));
+	vga_printf("Error code:       0x%x\n", frame->err_code);
+	vga_printf("Task:             %t\n", cur_task);
+	vga_printf("Causes:\n");
+
+# define pr_err_cause(cause, msg)                                                                  \
+	 if (caused_by(cause))                                                                         \
+		 vga_printf("%s\n", msg);
+
+	if (caused_by(PFC_PRESENT)) {
+		vga_printf(" - Present (P): The page fault was caused by a "
+		           "page-protection violation.\n");
+	} else {
+		vga_printf(" - Present (P): The page fault was caused by a non-present page.\n");
+	}
+
+	pr_err_cause(PFC_WRITE, " - Write (W): The page fault was caused by a write "
+	                        "access.")
+
+	    pr_err_cause(PFC_USER,
+	                 " - User (U): The page fault was caused while CPL = 3. This "
+	                 "does not necessarily mean that the page fault was a privilege violation.");
+
+	pr_err_cause(PFC_RESERVED,
+	             " - Reserved write (R): One or more page directory "
+	             "entries contain reserved bits which are set to 1. This only applies "
+	             "when the PSE or PAE flags in CR4 are set to 1.");
+
+	pr_err_cause(PFC_INSTR_FETCH,
+	             " - Instruction Fetch (I): The page fault was caused by an instruction "
+	             "fetch. This only applies when the No-Execute bit is supported and enabled.");
+
+	pr_err_cause(PFC_PROT_KEY,
+	             " - Protection key (PK): The page fault was caused by a "
+	             "protection-key violation. The PKRU register (for user-mode accesses) or PKRS "
+	             "MSR (for supervisor-mode accesses) specifies the protection key rights.");
+
+	pr_err_cause(PFC_SSTACK, " - Shadow stack (SS): The page fault was caused by a "
+	                         "shadow stack access.");
+
+	pr_err_cause(PFC_SOFT_GUARD_EX,
+	             " - Software Guard Extensions (SGX): The fault was "
+	             "due to an SGX violation. The fault is unrelated to ordinary paging.");
+
+# undef pr_err_cause
+
+	vga_printf("\n");
+
+#endif
+
+#undef caused_by
+
+	kpanic("Page fault");
 }
 
 void vmm_finalize(void)

--- a/src/memory/vmm.c
+++ b/src/memory/vmm.c
@@ -40,6 +40,8 @@ enum PageFaultCauses {
 
 void page_fault_handler(struct trap_frame *frame)
 {
+	(void)frame;
+
 #define caused_by(cause) FLAG_IS_SET(frame->err_code, cause)
 
 	void *faulting_address;

--- a/src/proc/task.c
+++ b/src/proc/task.c
@@ -365,21 +365,9 @@ struct task *task_find_by_pid(pid_t pid)
 	return NULL;
 }
 
-// ============================================================================
-// DEBUG APIs
-// ============================================================================
-
-void task_print_info(SHELL_ARGS)
+void task_print_info(struct task *task)
 {
-	if (argc != 2)
-		return;
-	pid_t        task_pid = ft_atoi(argv[1]);
-	struct task *task     = task_find_by_pid(task_pid);
-
-	if (!task) {
-		vga_printf("task_print_info: task pointer is NULL\n");
-		return;
-	}
+	assert(task);
 
 	vga_printf("Task Info (PID %d)\n", task->pid);
 	vga_printf("  - Name: %s\n", task->name);
@@ -407,6 +395,21 @@ void task_print_info(SHELL_ARGS)
 	}
 	vga_printf("\n");
 	vma_print_areas(&task->vma_areas);
+}
+
+void task_cmd_print_info(SHELL_ARGS)
+{
+	if (argc != 2)
+		return;
+	pid_t        task_pid = ft_atoi(argv[1]);
+	struct task *task     = task_find_by_pid(task_pid);
+
+	if (!task) {
+		vga_printf("task_print_info: task pointer is NULL\n");
+		return;
+	}
+
+	task_print_info(task);
 }
 
 void task_print_stack(const struct task *task)

--- a/src/proc/task.c
+++ b/src/proc/task.c
@@ -143,7 +143,7 @@ void task_append_child(struct task *parent, struct task *child)
 struct task *task_clone(const struct task *task)
 {
 	const size_t name_len   = ft_strlen(task->name);
-	const size_t alloc_size = sizeof(struct task) + sizeof(struct section) * 4 + name_len;
+	const size_t alloc_size = sizeof(struct task) + sizeof(struct section) * 5 + name_len;
 	struct task *const new  = kmalloc(alloc_size, __GFP_KERNEL | __GFP_ZERO);
 
 	if (new == NULL) {
@@ -164,17 +164,19 @@ struct task *task_clone(const struct task *task)
 	new->kernel_stack_pointer = 0;
 	new->kernel_stack_base    = 0;
 
-	new->heap_sec  = (struct section *)(new + 1);
-	new->text_sec  = new->heap_sec++;
-	new->data_sec  = new->heap_sec++;
-	new->stack_sec = new->heap_sec++;
+	new->heap_sec       = (struct section *)(new + 1);
+	new->text_sec       = new->heap_sec++;
+	new->data_sec       = new->heap_sec++;
+	new->stack_sec      = new->heap_sec++;
+	new->sig_trampoline = new->heap_sec++;
 
 	ft_memcpy(new->text_sec, task->text_sec, sizeof(struct section));
 	ft_memcpy(new->data_sec, task->data_sec, sizeof(struct section));
 	ft_memcpy(new->stack_sec, task->stack_sec, sizeof(struct section));
 	ft_memcpy(new->heap_sec, task->heap_sec, sizeof(struct section));
+	ft_memcpy(new->sig_trampoline, task->sig_trampoline, sizeof(struct section));
 
-	new->name = (char *)(new->heap_sec + 1);
+	new->name = (char *)(new->sig_trampoline + 1);
 	ft_memcpy(new->name, task->name, name_len);
 
 	new->pid = id_manager_alloc(pid_manager);

--- a/src/proc/task.c
+++ b/src/proc/task.c
@@ -42,10 +42,6 @@ __attribute__((constructor)) static void init_pid_manager(void)
 
 extern void interrupt_exit(void);
 
-// ============================================================================
-// INTERNAL APIs
-// ============================================================================
-
 static inline const char *task_state_to_string(enum process_states state)
 {
 	if (state == TASK_NEW)
@@ -99,7 +95,7 @@ static void task_init_dummy(void)
 
 static void task_init_idle(void)
 {
-	idle_task = task_get_new("Idle", false, NULL, NULL);
+	idle_task = task_get_new("Idle", 0, NULL, NULL);
 	if (!idle_task)
 		kpanic("Failed to init Idle\n");
 
@@ -115,7 +111,7 @@ static void task_init_kitoxD(void)
 	if (!section_init_from_buffer(&text, 0, kitoxD_start, fn_size, 0))
 		kpanic("Failed to init kitoxD sections\n");
 
-	kitoxD_task = task_get_new("kitoxD", true, &text, NULL);
+	kitoxD_task = task_get_new("kitoxD", 3, &text, NULL);
 	if (!kitoxD_task)
 		kpanic("Failed to init kitoxD\n");
 
@@ -145,8 +141,7 @@ void task_append_child(struct task *parent, struct task *child)
 
 // Text and data are used as templates; this function allocates its own internal sections
 // After return, the caller must free the input text and data if they were heap-allocated
-struct task *task_get_new(const char *name, bool userspace, struct section *text,
-                          struct section *data)
+struct task *task_get_new(const char *name, size_t ring, struct section *text, struct section *data)
 {
 	if (!name)
 		return NULL;
@@ -206,15 +201,19 @@ struct task *task_get_new(const char *name, bool userspace, struct section *text
 	                              (sig_trampoline_end - sig_trampoline_start), USER_SECTION_RO))
 		goto free_kstack;
 
-	if (userspace) {
+	ret->ring = ring;
+	switch (ring) {
+	case 3:
 		if (!userspace_create_new(ret))
 			goto free_kstack;
-		ret->ring = 3;
-	}
+		break;
 
-	else {
-		ret->cr3  = vmm_get_kernel_directory();
-		ret->ring = 0;
+	case 0:
+		ret->cr3 = vmm_get_kernel_directory();
+		break;
+
+	default:
+		kpanic("yo you damn crazy wtf r u doing?!");
 	}
 
 	ret->state = TASK_NEW;
@@ -227,10 +226,13 @@ struct task *task_get_new(const char *name, bool userspace, struct section *text
 	wq_init(&ret->child_wq);
 
 	INIT_SENTINEL(&ret->sched_node);
+
 	list_add_tail(&ret->info_node, &info_queue);
 	signal_init_default_handlers(ret);
+
 	INIT_SENTINEL(&ret->vma_areas);
-	if (userspace)
+
+	if (ring == 3)
 		vma_init_area(&ret->vma_areas, ret->heap_sec->v_addr, ret->stack_sec->v_addr - PAGE_SIZE);
 
 	/*
@@ -517,7 +519,7 @@ static void exec_fn(unsigned int *addr, unsigned int *function, unsigned int siz
 		text_ptr = &text;
 	}
 
-	struct task *sloppy_task = task_get_new("Sloppy", is_user, text_ptr, NULL);
+	struct task *sloppy_task = task_get_new("Sloppy", is_user ? 3 : 0, text_ptr, NULL);
 	if (!sloppy_task) {
 		vga_printf("exec_fn: Failed to allocate task structure\n");
 		return;

--- a/src/proc/task.c
+++ b/src/proc/task.c
@@ -157,6 +157,7 @@ struct task *task_clone(const struct task *task)
 	INIT_SENTINEL(&new->info_node);
 	INIT_SENTINEL(&new->sched_node);
 
+	wq_entry_init(&new->wq_data, new, TASK_INTERRUPTIBLE);
 	wq_init(&new->child_wq);
 
 	new->kernel_stack_pointer = 0;

--- a/src/proc/task.c
+++ b/src/proc/task.c
@@ -276,7 +276,6 @@ struct task *task_get_new(const char *name, size_t ring, struct section *text, s
 
 	ret->name = (char *)(ret->sig_trampoline + 1);
 	ft_memcpy(ret->name, name, name_len);
-	ret->name[name_len] = 0;
 
 	wq_entry_init(&ret->wq_data, ret, TASK_INTERRUPTIBLE);
 	wq_init(&ret->child_wq);

--- a/src/proc/task.c
+++ b/src/proc/task.c
@@ -139,6 +139,60 @@ void task_append_child(struct task *parent, struct task *child)
 	child->real_parent = parent;
 }
 
+struct task *task_clone(const struct task *task)
+{
+	const size_t name_len   = ft_strlen(task->name);
+	const size_t alloc_size = sizeof(struct task) + sizeof(struct section) * 4 + name_len;
+	struct task *const new  = kmalloc(alloc_size, __GFP_KERNEL | __GFP_ZERO);
+
+	if (new == NULL) {
+		return NULL;
+	}
+
+	ft_memcpy(new, task, sizeof(struct task));
+
+	INIT_SENTINEL(&new->children);
+	INIT_SENTINEL(&new->siblings);
+	INIT_SENTINEL(&new->vma_areas);
+	INIT_SENTINEL(&new->info_node);
+	INIT_SENTINEL(&new->sched_node);
+
+	wq_init(&new->child_wq);
+
+	new->kernel_stack_pointer = 0;
+	new->kernel_stack_base    = 0;
+
+	new->heap_sec  = (struct section *)(new + 1);
+	new->text_sec  = new->heap_sec++;
+	new->data_sec  = new->heap_sec++;
+	new->stack_sec = new->heap_sec++;
+
+	ft_memcpy(new->text_sec, task->text_sec, sizeof(struct section));
+	ft_memcpy(new->data_sec, task->data_sec, sizeof(struct section));
+	ft_memcpy(new->stack_sec, task->stack_sec, sizeof(struct section));
+	ft_memcpy(new->heap_sec, task->heap_sec, sizeof(struct section));
+
+	new->name = (char *)(new->heap_sec + 1);
+	ft_memcpy(new->name, task->name, name_len);
+
+	new->pid = id_manager_alloc(pid_manager);
+	if (new->pid < 0) {
+		kfree(new);
+		return NULL;
+	}
+
+	new->cr3 = (uintptr_t)buddy_alloc_pages(PAGE_SIZE, LOWMEM_ZONE);
+	if (!new->cr3) {
+		id_manager_free(pid_manager, new->pid);
+		kfree(new);
+		return NULL;
+	}
+
+	ft_bzero(PHYS_TO_VIRT_LINEAR(new->cr3), PAGE_SIZE);
+
+	return new;
+}
+
 // Text and data are used as templates; this function allocates its own internal sections
 // After return, the caller must free the input text and data if they were heap-allocated
 struct task *task_get_new(const char *name, size_t ring, struct section *text, struct section *data)

--- a/src/syscalls/fork.c
+++ b/src/syscalls/fork.c
@@ -96,7 +96,7 @@ SYSCALL_DEFINE0(fork)
 
 	sched_enqueue(new);
 
-	uint32_t *stack = (void *)child_tf;
+	uint32_t *stack = (uint32_t *)(new->kernel_stack_base - sizeof(struct trap_frame));
 	*(--stack)      = (uint32_t)interrupt_exit;
 
 	return new->pid;

--- a/src/syscalls/fork.c
+++ b/src/syscalls/fork.c
@@ -41,7 +41,7 @@ SYSCALL_DEFINE0(fork)
 	new->heap_sec->p_addr  = 0;
 	new->stack_sec->p_addr = 0;
 
-	for (int i = 0; i < 768; i++, current_pde++, new_pde++) {
+	for (uint32_t i = 0; i < 768; i++, current_pde++, new_pde++) {
 		if (FLAG_IS_SET(*current_pde, PDE_PRESENT_BIT)) {
 			uintptr_t new_pt_phys = (uintptr_t)buddy_alloc_pages(PAGE_SIZE, LOWMEM_ZONE);
 			if (!new_pt_phys)
@@ -54,7 +54,7 @@ SYSCALL_DEFINE0(fork)
 
 			ft_bzero(new_pte, PAGE_SIZE);
 
-			for (int j = 0; j < 1024; j++, current_pte++, new_pte++) {
+			for (uint32_t j = 0; j < 1024; j++, current_pte++, new_pte++) {
 				if (FLAG_IS_SET(*current_pte, PTE_PRESENT_BIT)) {
 					const uintptr_t page = (uintptr_t)buddy_alloc_pages(PAGE_SIZE, HIGHMEM_ZONE);
 					if (!page) {
@@ -70,15 +70,16 @@ SYSCALL_DEFINE0(fork)
 						goto fail_page_copy;
 					}
 
-					if (!vmm_map_page(new->cr3, i << 22 | j << 12, page,
-					                  GET_ENTRY_FLAGS(*current_pte))) {
+					const uintptr_t vaddr = ((uintptr_t)i << 22) | ((uintptr_t)j << 12);
+
+					if (!vmm_map_page(new->cr3, vaddr, page, GET_ENTRY_FLAGS(*current_pte))) {
 						vga_printf("fork: failed to map page into child page directory\n");
 						vmm_kunmap();
 						buddy_free_block((void *)page);
 						goto fail_page_copy;
 					}
 
-					ft_memcpy(window, (void *)(i << 22 | j << 12), PAGE_SIZE);
+					ft_memcpy(window, (void *)vaddr, PAGE_SIZE);
 					vmm_kunmap();
 				}
 			}

--- a/src/syscalls/fork.c
+++ b/src/syscalls/fork.c
@@ -1,5 +1,4 @@
 #include <arch/trap_frame.h>
-#include <drivers/vga.h>
 #include <kernel/panic.h>
 #include <libk.h>
 #include <list.h>
@@ -9,67 +8,101 @@
 #include <proc/scheduler.h>
 #include <proc/task.h>
 #include <syscalls/syscalls.h>
+#include <utils/assert.h>
 #include <utils/error.h>
 #include <utils/kmacro.h>
 
-extern void interrupt_exit(void);
+extern void         interrupt_exit(void);
+extern struct task *task_clone(const struct task *task);
 
 SYSCALL_DEFINE0(fork)
 {
-	struct trap_frame *parent_tf = NULL, *child_tf;
-	struct task       *current   = task_get_current_task(), *new;
-	uint32_t          *current_pde, *new_pde, *current_pte, *new_pte, *kstack;
+	struct task *current = task_get_current_task(), *new;
+	assert(current);
 
-	__asm__ volatile("mov (%%ebp), %%eax\n\t"
-	                 "mov 8(%%eax), %0"
-	                 : "=r"(parent_tf)
-	                 :
-	                 : "eax");
+	struct trap_frame *child_tf;
+	uint32_t          *current_pde, *new_pde, *current_pte, *new_pte;
 
-	if (!parent_tf)
-		return -EINVAL;
-
-	new = task_get_new(current->name, current->ring == 3, current->text_sec, current->data_sec);
+	new = task_clone(current);
 	if (!new)
 		return -ENOMEM;
 
-	task_append_child(current, new);
+	new->kernel_stack_pointer = (uintptr_t)kmalloc(DEFAULT_STACK_SIZE, __GFP_KERNEL | __GFP_ZERO);
+	if (!new->kernel_stack_pointer)
+		goto fail;
+
+	new->kernel_stack_base = new->kernel_stack_pointer + DEFAULT_STACK_SIZE;
 
 	current_pde = PHYS_TO_VIRT_LINEAR(current->cr3);
 	new_pde     = PHYS_TO_VIRT_LINEAR(new->cr3);
 
+	// Quick fix, should be really fixed further
+	new->text_sec->p_addr  = 0;
+	new->data_sec->p_addr  = 0;
+	new->heap_sec->p_addr  = 0;
+	new->stack_sec->p_addr = 0;
+
 	for (int i = 0; i < 768; i++, current_pde++, new_pde++) {
-		if (!FLAG_IS_SET(*current_pde, PDE_PRESENT_BIT))
-			continue;
+		if (FLAG_IS_SET(*current_pde, PDE_PRESENT_BIT)) {
+			uintptr_t new_pt_phys = (uintptr_t)buddy_alloc_pages(PAGE_SIZE, LOWMEM_ZONE);
+			if (!new_pt_phys)
+				goto fail;
 
-		*new_pde = GET_ENTRY_ADDR(*new_pde) | (*current_pde & ENTRY_FLAGS_MASK);
+			*new_pde = GET_ENTRY_ADDR(new_pt_phys) | GET_ENTRY_FLAGS(*current_pde);
 
-		current_pte = PHYS_TO_VIRT_LINEAR(GET_ENTRY_ADDR(*current_pde));
-		new_pte     = PHYS_TO_VIRT_LINEAR(GET_ENTRY_ADDR(*new_pde));
+			current_pte = PHYS_TO_VIRT_LINEAR(GET_ENTRY_ADDR(*current_pde));
+			new_pte     = PHYS_TO_VIRT_LINEAR(GET_ENTRY_ADDR(*new_pde));
 
-		for (int j = 0; j < 1024; j++, current_pte++, new_pte++) {
-			if (!FLAG_IS_SET(*current_pte, PTE_PRESENT_BIT))
-				continue;
+			ft_bzero(new_pte, PAGE_SIZE);
 
-			FLAG_UNSET(*current_pte, PTE_RW_BIT);
-			*new_pte = *current_pte;
+			for (int j = 0; j < 1024; j++, current_pte++, new_pte++) {
+				if (FLAG_IS_SET(*current_pte, PTE_PRESENT_BIT)) {
+
+					const uintptr_t page = (uintptr_t)buddy_alloc_pages(PAGE_SIZE, HIGHMEM_ZONE);
+					assert(page);
+
+					void *const window = vmm_kmap(page);
+					assert(window);
+
+					assert(vmm_map_page(new->cr3, i << 22 | j << 12, page,
+					                    GET_ENTRY_FLAGS(*current_pte)));
+
+					ft_memcpy(window, (void *)(i << 22 | j << 12), PAGE_SIZE);
+
+					vmm_kunmap();
+				}
+			}
 		}
 	}
 
+	ft_memcpy(new_pde, current_pde, 224 * sizeof(uint32_t));
+
+	ft_memcpy((void *)new->kernel_stack_pointer, (void *)current->kernel_stack_pointer,
+	          DEFAULT_STACK_SIZE);
+
+	assert(*(uint32_t *)(new->kernel_stack_pointer) == STACK_CANARY_MAGIC);
+	assert(*(uint32_t *)(current->kernel_stack_base - 4) ==
+	       *(uint32_t *)(new->kernel_stack_base - 4));
+
 	child_tf = (struct trap_frame *)(new->kernel_stack_base - sizeof(struct trap_frame));
-	ft_memcpy(child_tf, parent_tf, sizeof(struct trap_frame));
+	assert(ft_memcmp(child_tf, (void *)current->kernel_stack_base - sizeof(struct trap_frame),
+	                 sizeof(struct trap_frame)) == 0);
 	child_tf->regs.eax = 0;
 
-	kstack      = (uint32_t *)(new->kernel_stack_base - sizeof(struct trap_frame));
-	*(--kstack) = (uint32_t)interrupt_exit;
-	*(--kstack) = 0;
-	*(--kstack) = 0;
-	*(--kstack) = 0;
-	*(--kstack) = 0;
+	task_append_child(current, new);
 
-	new->esp   = (uintptr_t)kstack;
+	new->esp   = new->kernel_stack_pointer - (current->kernel_stack_pointer - current->esp);
 	new->state = TASK_RUNNING;
+
 	sched_enqueue(new);
 
+	uint32_t *stack = (void *)child_tf;
+	*(--stack)      = (uint32_t)interrupt_exit;
+
 	return new->pid;
+
+fail:
+	vmm_destroy_user_pd(new->cr3);
+	task_release(new);
+	return -ENOMEM;
 }

--- a/src/syscalls/fork.c
+++ b/src/syscalls/fork.c
@@ -99,6 +99,11 @@ SYSCALL_DEFINE0(fork)
 	uint32_t *stack = (uint32_t *)(new->kernel_stack_base - sizeof(struct trap_frame));
 	*(--stack)      = (uint32_t)interrupt_exit;
 
+	*(--stack) = 0; // ebp
+	*(--stack) = 0; // ebx
+	*(--stack) = 0; // esi
+	*(--stack) = 0; // edi
+
 	return new->pid;
 
 fail:

--- a/src/syscalls/fork.c
+++ b/src/syscalls/fork.c
@@ -12,8 +12,7 @@
 #include <utils/error.h>
 #include <utils/kmacro.h>
 
-extern void         interrupt_exit(void);
-extern struct task *task_clone(const struct task *task);
+extern void interrupt_exit(void);
 
 SYSCALL_DEFINE0(fork)
 {
@@ -29,7 +28,7 @@ SYSCALL_DEFINE0(fork)
 
 	new->kernel_stack_pointer = (uintptr_t)kmalloc(DEFAULT_STACK_SIZE, __GFP_KERNEL | __GFP_ZERO);
 	if (!new->kernel_stack_pointer)
-		goto fail;
+		goto fail_kernel_stack;
 
 	new->kernel_stack_base = new->kernel_stack_pointer + DEFAULT_STACK_SIZE;
 
@@ -46,7 +45,7 @@ SYSCALL_DEFINE0(fork)
 		if (FLAG_IS_SET(*current_pde, PDE_PRESENT_BIT)) {
 			uintptr_t new_pt_phys = (uintptr_t)buddy_alloc_pages(PAGE_SIZE, LOWMEM_ZONE);
 			if (!new_pt_phys)
-				goto fail;
+				goto fail_page_copy;
 
 			*new_pde = GET_ENTRY_ADDR(new_pt_phys) | GET_ENTRY_FLAGS(*current_pde);
 
@@ -57,18 +56,29 @@ SYSCALL_DEFINE0(fork)
 
 			for (int j = 0; j < 1024; j++, current_pte++, new_pte++) {
 				if (FLAG_IS_SET(*current_pte, PTE_PRESENT_BIT)) {
-
 					const uintptr_t page = (uintptr_t)buddy_alloc_pages(PAGE_SIZE, HIGHMEM_ZONE);
-					assert(page);
+					if (!page) {
+						vga_printf("fork: failed to allocate page for child process\n");
+						goto fail_page_copy;
+					}
 
 					void *const window = vmm_kmap(page);
-					assert(window);
 
-					assert(vmm_map_page(new->cr3, i << 22 | j << 12, page,
-					                    GET_ENTRY_FLAGS(*current_pte)));
+					if (!window) {
+						vga_printf("fork: failed to map page in kernel virtual memory\n");
+						buddy_free_block((void *)page);
+						goto fail_page_copy;
+					}
+
+					if (!vmm_map_page(new->cr3, i << 22 | j << 12, page,
+					                  GET_ENTRY_FLAGS(*current_pte))) {
+						vga_printf("fork: failed to map page into child page directory\n");
+						vmm_kunmap();
+						buddy_free_block((void *)page);
+						goto fail_page_copy;
+					}
 
 					ft_memcpy(window, (void *)(i << 22 | j << 12), PAGE_SIZE);
-
 					vmm_kunmap();
 				}
 			}
@@ -106,7 +116,10 @@ SYSCALL_DEFINE0(fork)
 
 	return new->pid;
 
-fail:
+fail_page_copy:
+	kfree((void *)new->kernel_stack_pointer);
+
+fail_kernel_stack:
 	vmm_destroy_user_pd(new->cr3);
 	task_release(new);
 	return -ENOMEM;


### PR DESCRIPTION
## Summary

This PR fixes and improves the fork system call and related infrastructure. Key changes include fixing page table flag operations, refactoring task initialization APIs, enhancing debugging capabilities, and implementing deep copy semantics for process forking.

## Changes

### Core Fork Fixes & Improvements
- **fix(sys_fork): Invert `present` flag checks and RW flag operation** — Corrects page table entry flag logic in the fork implementation (`src/syscalls/fork.c`)
- **fix(fork): Implement deep copy of process memory** — Replaces shallow copy with proper deep copy of page tables and memory pages for child processes
- **dev(fork): Add proper kernel stack allocation** — Allocates dedicated kernel stacks for forked processes with proper initialization

### Task Management Refactoring
- **dev(task_get_new): Replace `bool userspace` with `size_t ring`** — Changes privilege level parameter from boolean to ring level (0 for kernel, 3 for user), providing better clarity and extensibility
- **dev(task_print_info): Refactor task info printing** — Splits functionality into:
  - `task_print_info(struct task *task)` — Direct task info printing (internal API)
  - `task_cmd_print_info(SHELL_ARGS)` — Shell command wrapper that looks up task by PID
- **feat: Add `task_clone()` function** — New function for creating a deep copy of a task structure with properly initialized resources

### Virtual Memory Improvements
- **fix(vmm): Add missing macro `GET_ENTRY_FLAGS()`** — Extracts entry flags from page directory/table entries
- **fix(vmm): Cast addresses to `uintptr_t` in macros** — Ensures type safety in page table macros (`GET_PDE_INDEX`, `GET_PTE_INDEX`, `GET_ENTRY_ADDR`)
- **dev(page_fault_handler): Enhance logging with detailed diagnostics** — Expanded debug output showing:
  - Faulting address and instruction pointer
  - Page directory and page table information
  - Error code with interpretation of each flag
  - Current task information via new debug format specifier
  - Detailed explanations of page fault causes

### Compiler & Utils Enhancements
- **dev(utils/compiler.h): Add compiler-specific macros** — Introduction of compiler feature detection macros
- **dev(ft_putchar): Route output to serial** — Character output now sent to serial device instead of just VGA
- **dbg(vga_printf): Add `%t` format specifier** — New debug format to print minimal task information (address, name, PID)

### Architecture & Header Updates
- **fix(include/arch/trap_frame.h): Add static assertions** — Validates `struct trap_frame` memory layout at compile time
- **fix(include/list.h): Simplify `list_entry` macro** — Removes unnecessary type casting, delegating to `container_of`
- **fix(include/memory/vmm.h): Add type casts** — Ensures proper type handling in virtual memory macros

### Additional Fixes
- **dev(drivers/tty): Update task_info command** — Shell command now uses the refactored `task_cmd_print_info()` wrapper