### PR TITLE
rework kpanic

### DIFF
--- a/include/drivers/vga.h
+++ b/include/drivers/vga.h
@@ -5,6 +5,7 @@
 // ============================================================================
 
 #include <memory/memory.h>
+#include <stdarg.h>
 #include <types.h>
 
 // ============================================================================
@@ -72,4 +73,5 @@ void vga_set_cursor_position(uint8_t x, uint8_t y);
 void vga_set_mode(enum vga_color mode);
 void vga_setup_default_screen(void);
 void vga_refresh_screen(void);
-void vga_printf(const char *fmt, ...);
+void vga_printf(const char *restrict fmt, ...);
+void vga_vprintf(const char *restrict fmt, va_list ap);

--- a/include/kernel/panic.h
+++ b/include/kernel/panic.h
@@ -1,21 +1,10 @@
 #pragma once
 
-#include <arch/acpi.h>
-#include <drivers/tty.h>
-#include <proc/lock.h>
 #include <types.h>
 
-#define kpanic(msg, ...)                                                                           \
-	do {                                                                                           \
-		lock_irq();                                                                                \
-		tty_framebuffer_set_screen_mode(current_tty, VGA_COLOR(VGA_COLOR_RED, VGA_COLOR_WHITE));   \
-		vga_disable_cursor();                                                                      \
-		vga_printf("\n------------------------------------\n");                                    \
-		print_stack_frame();                                                                       \
-		vga_printf("------------------------------------\n");                                      \
-		vga_printf("PANIC in %s:%d\n", __FILE__, __LINE__);                                        \
-		vga_printf(msg, ##__VA_ARGS__);                                                            \
-		halt();                                                                                    \
-	} while (0)
+#define kpanic(fmt, ...)                                                                           \
+	__kpanic("PANIC in %s:%d\n"                                                                    \
+	         "%s: " fmt "\n",                                                                      \
+	         __FILE__, __LINE__, __func__, ##__VA_ARGS__)
 
-void print_stack_frame(void);
+void __noreturn __kpanic(const char *fmt, ...);

--- a/include/utils/assert.h
+++ b/include/utils/assert.h
@@ -1,25 +1,21 @@
 #pragma once
 
-#include <arch/acpi.h>
-#include <drivers/tty.h>
-#include <utils/kmacro.h>
-
-#define __assert_fail(expr)                                                                        \
-	({                                                                                             \
-		vga_disable_cursor();                                                                      \
-		tty_framebuffer_set_screen_mode(current_tty, VGA_COLOR(VGA_COLOR_RED, VGA_COLOR_WHITE));   \
-		log("%s(): Assertion `%s' failed.", __func__, #expr);                                      \
-		halt();                                                                                    \
-	})
-
 #define static_assert _Static_assert
 
 #ifndef NDEBUG
 
-# define assert(expr) ((expr) ? (void)(0) : __assert_fail(expr))
+# include <kernel/panic.h>
+
+# define __assert_fail(expr) kpanic("Assertion `%s' failed.", #expr)
+
+# define assert(expr)                                                                              \
+	 do {                                                                                          \
+		 if (unlikely(!(expr)))                                                                    \
+			 __assert_fail(expr);                                                                  \
+	 } while (0)
 
 #else
 
-# define assert(expr)
+# define assert(expr) ((void)0)
 
 #endif

--- a/src/drivers/vga/vga.c
+++ b/src/drivers/vga/vga.c
@@ -157,11 +157,17 @@ void vga_refresh_screen(void)
 	vga_set_cursor_position(current_tty->cursor.x, current_tty->cursor.y);
 }
 
-void vga_printf(const char *fmt, ...)
+void vga_printf(const char *restrict fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);
 
+	vga_vprintf(fmt, ap);
+	va_end(ap);
+}
+
+void vga_vprintf(const char *fmt, va_list ap)
+{
 	for (unsigned long i = 0; fmt[i]; i++) {
 		if (fmt[i] == '%') {
 			switch (fmt[++i]) {

--- a/src/kernel/panic.c
+++ b/src/kernel/panic.c
@@ -2,7 +2,12 @@
 #include <drivers/tty.h>
 #include <drivers/vga.h>
 #include <kernel/panic.h>
+#include <memory/kmalloc.h>
+#include <memory/memory.h>
+#include <proc/lock.h>
+#include <stdarg.h>
 #include <types.h>
+#include <utils/compiler.h>
 
 static uint8_t stack_snapshot[4096];
 
@@ -45,4 +50,19 @@ void print_stack_frame(void)
 	vga_printf("ESP = %p | EBP = %p\n", esp, ebp);
 	uint32_t eip = *(ebp + 1);
 	vga_printf("Return address: 0x%x\n", eip);
+}
+
+void __noreturn __kpanic(const char *fmt, ...)
+{
+	va_list ap;
+
+	lock_irq();
+	tty_framebuffer_set_screen_mode(current_tty, VGA_COLOR(VGA_COLOR_RED, VGA_COLOR_WHITE));
+	vga_disable_cursor();
+
+	va_start(ap, fmt);
+	vga_vprintf(fmt, ap);
+	va_end(ap);
+
+	halt();
 }

--- a/src/memory/boot_allocator.c
+++ b/src/memory/boot_allocator.c
@@ -1,12 +1,12 @@
 #include <arch/acpi.h>
+#include <arch/x86.h>
+#include <drivers/vga.h>
 #include <kernel/panic.h>
 #include <libk.h>
 #include <memory/boot_allocator.h>
 #include <memory/memory.h>
 #include <types.h>
 #include <utils/kmacro.h>
-
-#include <arch/x86.h>
 
 // Header
 

--- a/src/memory/vma.c
+++ b/src/memory/vma.c
@@ -1,3 +1,4 @@
+#include <drivers/vga.h>
 #include <kernel/panic.h>
 #include <libk.h>
 #include <list.h>


### PR DESCRIPTION
- **fix(sys_fork): Invert `present` flag checks and RW flag operation**
- **rename: Remove `sys_` prefix from `src/syscalls/sys_*.c`**
- **dev(utils/compiler.h): Add and use compiler specifics marcos**
- **rework(kpanic): rework `__kpanic' and `__assert_fail' in order to have symbols**
